### PR TITLE
fallback name for levels if actual name is empty string

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementLevel.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementLevel.cpp
@@ -46,7 +46,16 @@ std::string HostToSpeckleConverter::GetElementLevel(const std::string& elemId)
 		}
 	}
 
-	return floorName;
+	if (!floorName.empty())
+	{
+		return floorName;
+	}
+	else
+	{
+		std::ostringstream oss;
+		oss << floorInd << ". Story";
+		return oss.str();
+	}
 }
 
 #pragma warning(pop) // Restore the previous warning state


### PR DESCRIPTION
- Element Level names can be empty strings in Archicad but they always have a Story index
- If the name is empty then we fall back to a name based on the index: "{StoryIndex}. Story"
<img width="233" alt="image" src="https://github.com/user-attachments/assets/a3eb2f5b-d3e2-429a-a3e2-0465a75ccf45" />
