### PR TITLE
CNX 939 no direct conversion found for type specklesdkmodelsbase

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementBody.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementBody.cpp
@@ -227,5 +227,8 @@ ElementBody HostToSpeckleConverter::GetElementBody(const std::string& elemId)
 		}
 	}
 
+	if (elementBody.meshes.empty())
+		throw SpeckleConversionException("Element DisplayValue was empty");
+
 	return elementBody;
 }

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.cpp
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.cpp
@@ -8,6 +8,9 @@ void to_json(nlohmann::json& j, const ArchicadObject& elem)
     j["speckle_type"] = elem.speckle_type;
     j["applicationId"] = elem.applicationId;
     j["units"] = elem.units;
-    j["@displayValue"] = elem.displayValue;
+    if (!elem.displayValue.meshes.empty())
+    {
+        j["@displayValue"] = elem.displayValue;
+    }
     j["properties"] = elem.properties;
 }


### PR DESCRIPTION
- The connector will not send the displayValue if it's empty
- There was an issue with Elements with no meshes (window openings)