### PR TITLE
Beam Column empty DisplayValue bugfix

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementBody.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementBody.cpp
@@ -227,8 +227,5 @@ ElementBody HostToSpeckleConverter::GetElementBody(const std::string& elemId)
 		}
 	}
 
-	if (elementBody.meshes.empty())
-		throw SpeckleConversionException("Element DisplayValue was empty");
-
 	return elementBody;
 }

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.cpp
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.cpp
@@ -7,11 +7,7 @@ void to_json(nlohmann::json& j, const ArchicadObject& elem)
     j["level"] = elem.level;
     j["speckle_type"] = elem.speckle_type;
     j["applicationId"] = elem.applicationId;
-    j["units"] = elem.units;
-    if (!elem.displayValue.meshes.empty())
-    {
-        j["@displayValue"] = elem.displayValue;
-    }
+    j["@displayValue"] = elem.displayValue;
     j["properties"] = elem.properties;
     j["@elements"] = elem.elements;
 }

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
@@ -11,7 +11,6 @@ struct ArchicadObject
     std::string level = "";
     std::string speckle_type = "Objects.Data.ArchicadObject";
     std::string applicationId = "";
-    std::string units = "m"; // default to meters
     ElementBody displayValue;
     nlohmann::json properties;
     std::vector<ArchicadObject> elements;


### PR DESCRIPTION
- Send empty array when DisplayValue is empty
- ModelElements with empty Meshes might still contain useful information
- Fixes Beam, Column receive bug in Rhino

<img width="860" alt="image" src="https://github.com/user-attachments/assets/73dc7551-6704-44ac-8091-6336592455da" />
