### PR TITLE
large send stuck bugfix

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
@@ -117,7 +117,7 @@ void SendBridge::Send(const RunMethodEventArgs& args)
 
         BaseObjectSerializer serializer{};
         auto rootObjectId = serializer.Serialize(root);
-        auto batches = serializer.BatchObjects();
+        auto batches = serializer.BatchObjects(10);
 
         sendArgs.referencedObjectId = rootObjectId;
 


### PR DESCRIPTION
- Batch size is set to 10MB from 100MB 
- Could not finish send with 100MB batches on a model with 13.000 elements