### PR TITLE
fixing revit and autocad material receive issues from archicad model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/build
 **/build_26
+**/build_27_ext
 **/build_27
 **/build_28
 **/node_modules

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetModelMaterial.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetModelMaterial.cpp
@@ -17,7 +17,10 @@ Material HostToSpeckleConverter::GetModelMaterial(int materialIndex)
 	acModel.GetMaterial(attributeIndex, &modelerMaterial);
 
 	auto color = modelerMaterial.GetSurfaceColor();
+	auto name = modelerMaterial.GetName().ToCStr().Get();
+
 	Material material;
+	material.name = name;
 	material.diffuse = ARGBColorConverter::PackARGB(1.0, color.red, color.green, color.blue);
 	double transparent = modelerMaterial.GetTransparency();
 	double shiny = modelerMaterial.GetShining();

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/Material.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/Material.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "json.hpp"
+#include "GuidGenerator.h"
 
 struct Material
 {
     std::string speckle_type = "Objects.Other.RenderMaterial";
-    std::string name = "RenderMaterial";
-    std::string applicationId = "D2417E06-1AA5-1714-D29A-1EC8F0830654"; //TODO: remove default
+    std::string name = "";
+    std::string applicationId = GuidGenerator::NewGuid();
     uint32_t diffuse = 0;
     double opacity = 1.0;
     double emissive = 0.0;


### PR DESCRIPTION
Receiving materials in Revit and Autocad failed, because material names were not exported.

![Screenshot 2025-02-26 190810](https://github.com/user-attachments/assets/a750599c-2d48-40bc-bacc-d7467a3c7a41)

![Screenshot 2025-02-26 191349](https://github.com/user-attachments/assets/68399215-2155-44e5-a6fd-38d2f2c17e9d)
