### PR TITLE
feat (archicad) implement view filter

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
@@ -91,7 +91,7 @@ void SendBridge::Send(const RunMethodEventArgs& args)
     sendArgs.accountId = modelCard.accountId;
     sendArgs.token = CONNECTOR.GetAccountDatabase().GetTokenByAccountId(modelCard.accountId);
 
-    CONNECTOR.GetSpeckleToHostConverter().ShowAllIn3D();
+    CONNECTOR.GetSpeckleToHostConverter().ShowIn3D();
 
     try
     {

--- a/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
@@ -57,7 +57,13 @@ void SendBridge::GetSendFilters(const RunMethodEventArgs& args)
         elementTypeFilter.availableCategories.push_back({ typeName, typeName });
     }
 
-    auto filters = nlohmann::json::array({ selectionFilter, elementTypeFilter });
+    ArchicadViewsFilter viewsFilter;
+    for (const auto& navigatorView : CONNECTOR.GetHostToSpeckleConverter().GetNavigatorViews())
+    {
+        viewsFilter.availableViews.push_back(navigatorView.name);
+    }
+
+    auto filters = nlohmann::json::array({ selectionFilter, elementTypeFilter, viewsFilter });
     args.eventSource->SetResult(args.methodId, filters);
 }
 

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementList.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementList.cpp
@@ -114,24 +114,6 @@ std::vector<std::string> HostToSpeckleConverter::GetElementList(const std::vecto
 	return elementList;
 }
 
-std::vector<std::string> HostToSpeckleConverter::GetElementListAll()
-{
-    //return GetElementList(GetElementTypeList());
-
-    std::vector<std::string> elementList;
-
-    GS::Array<API_Guid> elemGuids;
-    //CHECK_ERROR(ACAPI_Element_GetElemList(API_ZombieElemID, &elemGuids));
-    ACAPI_Element_GetElemList(API_ZombieElemID, &elemGuids, APIFilt_OnVisLayer | APIFilt_In3D);
-    for (const auto& apiGuid : elemGuids)
-    {
-        std::string guid = APIGuidToString(apiGuid).ToCStr().Get();
-        elementList.push_back(guid);
-    }
-
-    return elementList;
-}
-
 std::vector<std::string> HostToSpeckleConverter::GetElementTypeList()
 {
     return {

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementList.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementList.cpp
@@ -114,6 +114,24 @@ std::vector<std::string> HostToSpeckleConverter::GetElementList(const std::vecto
 	return elementList;
 }
 
+std::vector<std::string> HostToSpeckleConverter::GetElementListAll()
+{
+    //return GetElementList(GetElementTypeList());
+
+    std::vector<std::string> elementList;
+
+    GS::Array<API_Guid> elemGuids;
+    //CHECK_ERROR(ACAPI_Element_GetElemList(API_ZombieElemID, &elemGuids));
+    ACAPI_Element_GetElemList(API_ZombieElemID, &elemGuids, APIFilt_OnVisLayer | APIFilt_In3D);
+    for (const auto& apiGuid : elemGuids)
+    {
+        std::string guid = APIGuidToString(apiGuid).ToCStr().Get();
+        elementList.push_back(guid);
+    }
+
+    return elementList;
+}
+
 std::vector<std::string> HostToSpeckleConverter::GetElementTypeList()
 {
     return {

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementListAllVisibleIn3D.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementListAllVisibleIn3D.cpp
@@ -1,0 +1,17 @@
+#include "HostToSpeckleConverter.h"
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+
+std::vector<std::string> HostToSpeckleConverter::GetElementListAllVisibleIn3D()
+{
+    std::vector<std::string> elementList;
+    GS::Array<API_Guid> elemGuids;
+    ACAPI_Element_GetElemList(API_ZombieElemID, &elemGuids, APIFilt_OnVisLayer | APIFilt_In3D);
+    for (const auto& apiGuid : elemGuids)
+    {
+        std::string guid = APIGuidToString(apiGuid).ToCStr().Get();
+        elementList.push_back(guid);
+    }
+
+    return elementList;
+}

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetNavigatorViews.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetNavigatorViews.cpp
@@ -1,17 +1,10 @@
 #include "HostToSpeckleConverter.h"
-#include "ConverterUtils.h"
-#include "ElementTypeToStringConverter.h"
-
 #include "APIEnvir.h"
 #include "ACAPinc.h"
-#include "CheckError.h"
 
 std::vector<NavigatorView> HostToSpeckleConverter::GetNavigatorViews()
 {
 	std::vector<NavigatorView> navigatorViews;
-
-	//API_NavigatorView   view;
-	//API_NavigatorItem   parent;
 	API_NavigatorItem   item = {};
 	GS::Array<API_NavigatorItem> items;
 
@@ -26,8 +19,6 @@ std::vector<NavigatorView> HostToSpeckleConverter::GetNavigatorViews()
 
 	for (API_NavigatorItem& navItem : items)
 	{
-		//err = ACAPI_Navigator_GetNavigatorView(&navItem, &view);
-		//auto dbi = navItem.db;
 		std::string name = GS::UniString(navItem.uName).ToCStr().Get();
 		std::string guid = APIGuidToString(navItem.guid).ToCStr().Get();
 		navigatorViews.push_back({ name, guid });

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetNavigatorViews.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetNavigatorViews.cpp
@@ -1,0 +1,37 @@
+#include "HostToSpeckleConverter.h"
+#include "ConverterUtils.h"
+#include "ElementTypeToStringConverter.h"
+
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+#include "CheckError.h"
+
+std::vector<NavigatorView> HostToSpeckleConverter::GetNavigatorViews()
+{
+	std::vector<NavigatorView> navigatorViews;
+
+	//API_NavigatorView   view;
+	//API_NavigatorItem   parent;
+	API_NavigatorItem   item = {};
+	GS::Array<API_NavigatorItem> items;
+
+	item.itemType = API_PerspectiveNavItem;
+	item.mapId = API_PublicViewMap;
+	GSErrCode err = ACAPI_Navigator_SearchNavigatorItem(&item, &items);
+
+	if (err != NoError)
+	{
+		return {};
+	}
+
+	for (API_NavigatorItem& navItem : items)
+	{
+		//err = ACAPI_Navigator_GetNavigatorView(&navItem, &view);
+		//auto dbi = navItem.db;
+		std::string name = GS::UniString(navItem.uName).ToCStr().Get();
+		std::string guid = APIGuidToString(navItem.guid).ToCStr().Get();
+		navigatorViews.push_back({ name, guid });
+	}
+
+	return navigatorViews;
+}

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
@@ -9,6 +9,7 @@ public:
 
 	std::vector<std::string> GetSelection() override;
 	std::vector<std::string> GetElementList(const std::vector<std::string>& elementTypes) override;
+	std::vector<std::string> GetElementListAll() override;
 	std::vector<std::string> GetElementTypeList() override;
 	ElementBody GetElementBody(const std::string& elemId) override;
 	Material GetModelMaterial(int materialIndex) override;
@@ -28,4 +29,5 @@ public:
 	ArchicadObject GetArchicadObject(const std::string& elemId, SendConversionResult& conversionResult) override;
 	std::vector<ArchicadObject> GetElementChildren(const std::string& elemId) override;
 	std::string GetResourceString(short resourceId) override;
+	std::vector<NavigatorView> GetNavigatorViews() override;
 };

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
@@ -9,7 +9,7 @@ public:
 
 	std::vector<std::string> GetSelection() override;
 	std::vector<std::string> GetElementList(const std::vector<std::string>& elementTypes) override;
-	std::vector<std::string> GetElementListAll() override;
+	std::vector<std::string> GetElementListAllVisibleIn3D() override;
 	std::vector<std::string> GetElementTypeList() override;
 	ElementBody GetElementBody(const std::string& elemId) override;
 	Material GetModelMaterial(int materialIndex) override;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
@@ -7,6 +7,7 @@
 #include "ArchicadObject.h"
 #include "SendConversionResult.h"
 #include "PropertyFilters.h"
+#include "NavigatorView.h"
 
 class IHostToSpeckleConverter 
 {
@@ -15,6 +16,7 @@ public:
 
 	virtual std::vector<std::string> GetSelection() = 0;
 	virtual std::vector<std::string> GetElementList(const std::vector<std::string>& elementTypes) = 0;
+	virtual std::vector<std::string> GetElementListAll() = 0;
 	virtual std::vector<std::string> GetElementTypeList() = 0;
 	virtual ElementBody GetElementBody(const std::string& elemId) = 0;
 	virtual Material GetModelMaterial(int materialIndex) = 0;
@@ -34,4 +36,5 @@ public:
 	virtual ArchicadObject GetArchicadObject(const std::string& elemId, SendConversionResult& conversionResult) = 0;
 	virtual std::vector<ArchicadObject> GetElementChildren(const std::string& elemId) = 0;
 	virtual std::string GetResourceString(short resourceId) = 0;
+	virtual std::vector<NavigatorView> GetNavigatorViews() = 0;
 };

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
@@ -16,7 +16,7 @@ public:
 
 	virtual std::vector<std::string> GetSelection() = 0;
 	virtual std::vector<std::string> GetElementList(const std::vector<std::string>& elementTypes) = 0;
-	virtual std::vector<std::string> GetElementListAll() = 0;
+	virtual std::vector<std::string> GetElementListAllVisibleIn3D() = 0;
 	virtual std::vector<std::string> GetElementTypeList() = 0;
 	virtual ElementBody GetElementBody(const std::string& elemId) = 0;
 	virtual Material GetModelMaterial(int materialIndex) = 0;

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ISpeckleToHostConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ISpeckleToHostConverter.h
@@ -13,6 +13,7 @@ public:
 
 	virtual void SetSelection(std::vector<std::string> guids) = 0;
 	virtual void ShowAllIn3D() = 0;
+	virtual void SetView(const std::string& viewName) = 0;
 	virtual int CreateMaterial(const Material& material, const std::string& baseGroupName) = 0;
 	virtual int CreateMaterial(const ColorProxy& color, const std::string& baseGroupName) = 0;
 	virtual std::string CreateMorph(const Mesh& mesh, const int materialIndex, const std::string& baseGroupName) = 0;

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ISpeckleToHostConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ISpeckleToHostConverter.h
@@ -13,6 +13,7 @@ public:
 
 	virtual void SetSelection(std::vector<std::string> guids) = 0;
 	virtual void ShowAllIn3D() = 0;
+	virtual void ShowIn3D() = 0;
 	virtual void SetView(const std::string& viewName) = 0;
 	virtual int CreateMaterial(const Material& material, const std::string& baseGroupName) = 0;
 	virtual int CreateMaterial(const ColorProxy& color, const std::string& baseGroupName) = 0;

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SetView.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SetView.cpp
@@ -1,0 +1,40 @@
+#include "SpeckleToHostConverter.h"
+
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+#include "CheckError.h"
+
+void SpeckleToHostConverter::SetView(const std::string& viewName)
+{
+	API_NavigatorView   view;
+	API_NavigatorItem   item = {};
+	GS::Array<API_NavigatorItem> items;
+
+	item.itemType = API_PerspectiveNavItem;
+	item.mapId = API_PublicViewMap;
+	GSErrCode err = ACAPI_Navigator_SearchNavigatorItem(&item, &items);
+
+	if (err != NoError)
+	{
+		return;
+	}
+
+	for (API_NavigatorItem& navItem : items)
+	{
+		CHECK_ERROR(ACAPI_Navigator_GetNavigatorView(&navItem, &view));
+		std::string name = GS::UniString(navItem.uName).ToCStr().Get();
+		if (name == viewName)
+		{
+			auto dbInfo = navItem.db;
+			//CHECK_ERROR(ACAPI_Window_ChangeWindow(&dbInfo));
+			err = ACAPI_View_GoToView(APIGuidToString(navItem.guid).ToCStr());
+
+			if (err != NoError)
+			{
+				break;
+			}
+
+			break;
+		}
+	}
+}

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SetView.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SetView.cpp
@@ -1,13 +1,10 @@
 #include "SpeckleToHostConverter.h"
-
 #include "APIEnvir.h"
 #include "ACAPinc.h"
-#include "CheckError.h"
 
 void SpeckleToHostConverter::SetView(const std::string& viewName)
 {
-	API_NavigatorView   view;
-	API_NavigatorItem   item = {};
+	API_NavigatorItem item = {};
 	GS::Array<API_NavigatorItem> items;
 
 	item.itemType = API_PerspectiveNavItem;
@@ -21,19 +18,10 @@ void SpeckleToHostConverter::SetView(const std::string& viewName)
 
 	for (API_NavigatorItem& navItem : items)
 	{
-		CHECK_ERROR(ACAPI_Navigator_GetNavigatorView(&navItem, &view));
 		std::string name = GS::UniString(navItem.uName).ToCStr().Get();
 		if (name == viewName)
 		{
-			auto dbInfo = navItem.db;
-			//CHECK_ERROR(ACAPI_Window_ChangeWindow(&dbInfo));
-			err = ACAPI_View_GoToView(APIGuidToString(navItem.guid).ToCStr());
-
-			if (err != NoError)
-			{
-				break;
-			}
-
+			ACAPI_View_GoToView(APIGuidToString(navItem.guid).ToCStr());
 			break;
 		}
 	}

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ShowAllIn3D.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ShowAllIn3D.cpp
@@ -8,3 +8,15 @@ void SpeckleToHostConverter::ShowAllIn3D()
 {
 	CHECK_ERROR(ACAPI_View_ShowAllIn3D());
 }
+
+void SpeckleToHostConverter::ShowIn3D()
+{
+	API_WindowInfo currentWindowInfo = {};
+	ACAPI_Window_GetCurrentWindow(&currentWindowInfo);
+	if (currentWindowInfo.typeID != APIWind_3DModelID)
+	{
+		API_WindowInfo newWindowInfo = {};
+		newWindowInfo.typeID = APIWind_3DModelID;
+		CHECK_ERROR(ACAPI_Window_ChangeWindow(&newWindowInfo));
+	}
+}

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SpeckleToHostConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SpeckleToHostConverter.h
@@ -9,6 +9,7 @@ public:
 
 	void SetSelection(std::vector<std::string> guids) override;
 	void ShowAllIn3D() override;
+	void SetView(const std::string& viewName) override;
 	int CreateMaterial(const Material& material, const std::string& materialName) override;
 	int CreateMaterial(const ColorProxy& color, const std::string& materialName) override;
 	std::string CreateMorph(const Mesh& mesh, const int materialIndex, const std::string& baseGroupName) override;

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SpeckleToHostConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SpeckleToHostConverter.h
@@ -9,6 +9,7 @@ public:
 
 	void SetSelection(std::vector<std::string> guids) override;
 	void ShowAllIn3D() override;
+	void ShowIn3D() override;
 	void SetView(const std::string& viewName) override;
 	int CreateMaterial(const Material& material, const std::string& materialName) override;
 	int CreateMaterial(const ColorProxy& color, const std::string& materialName) override;

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadViewsFilter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadViewsFilter.cpp
@@ -31,6 +31,5 @@ void ArchicadViewsFilter::UpdateSelectedObjectIds()
 {
     // TODO CONNECTOR singleton should not be used in a DataType
     CONNECTOR.GetSpeckleToHostConverter().SetView(selectedView);
-    selectedObjectIds = CONNECTOR.GetHostToSpeckleConverter().GetElementListAll();
-    //selectedObjectIds = {};
+    selectedObjectIds = CONNECTOR.GetHostToSpeckleConverter().GetElementListAllVisibleIn3D();
 }

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadViewsFilter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadViewsFilter.cpp
@@ -1,0 +1,36 @@
+#include "ArchicadViewsFilter.h"
+#include "Connector.h"
+
+void to_json(nlohmann::json& j, const ArchicadViewsFilter& filter)
+{
+    j["typeDiscriminator"] = filter.typeDiscriminator;
+    j["selectedObjectIds"] = filter.selectedObjectIds;
+    j["name"] = filter.name;
+    j["id"] = filter.id;
+    j["type"] = filter.type;
+    j["summary"] = filter.summary;
+    j["isDefault"] = filter.isDefault;
+    j["selectedView"] = filter.selectedView;
+    j["availableViews"] = filter.availableViews;
+}
+
+void from_json(const nlohmann::json& j, ArchicadViewsFilter& filter)
+{
+    filter.typeDiscriminator = j.at("typeDiscriminator").get<std::string>();
+    filter.selectedObjectIds = j.at("selectedObjectIds").get<std::vector<std::string>>();
+    filter.name = j.at("name").get<std::string>();
+    filter.id = j.at("id").get<std::string>();
+    filter.type = j.at("type").get<std::string>();
+    filter.summary = j.at("summary").get<std::string>();
+    filter.isDefault = j.at("isDefault").get<bool>();
+    filter.selectedView = j.at("selectedView").get<std::string>();
+    filter.availableViews = j.at("availableViews").get<std::vector<std::string>>();
+}
+
+void ArchicadViewsFilter::UpdateSelectedObjectIds()
+{
+    // TODO CONNECTOR singleton should not be used in a DataType
+    CONNECTOR.GetSpeckleToHostConverter().SetView(selectedView);
+    selectedObjectIds = CONNECTOR.GetHostToSpeckleConverter().GetElementListAll();
+    //selectedObjectIds = {};
+}

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadViewsFilter.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadViewsFilter.h
@@ -8,8 +8,8 @@ struct ArchicadViewsFilter
     std::string typeDiscriminator = "ArchicadViewsFilter";
     std::vector<std::string> selectedObjectIds;
     std::string name = "Views";
-    // revitCategories was first implemented on UI
-    // it will be used in Archicad as well for element type filters
+    // revitViews was first implemented on UI
+    // it will be used in Archicad as well for views filter
     std::string id = "revitViews";
     std::string type = "Custom";
     std::string summary;

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadViewsFilter.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadViewsFilter.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "json.hpp"
+#include "CategoryData.h"
+
+struct ArchicadViewsFilter
+{
+    std::string typeDiscriminator = "ArchicadViewsFilter";
+    std::vector<std::string> selectedObjectIds;
+    std::string name = "Views";
+    // revitCategories was first implemented on UI
+    // it will be used in Archicad as well for element type filters
+    std::string id = "revitViews";
+    std::string type = "Custom";
+    std::string summary;
+    bool isDefault = false;
+    std::string selectedView;
+    std::vector<std::string> availableViews;
+
+    void UpdateSelectedObjectIds();
+};
+
+void to_json(nlohmann::json& j, const ArchicadViewsFilter& filter);
+void from_json(const nlohmann::json& j, ArchicadViewsFilter& filter);

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/NavigatorView.cpp
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/NavigatorView.cpp
@@ -1,0 +1,13 @@
+#include "NavigatorView.h"
+
+void to_json(nlohmann::json& j, const NavigatorView& view)
+{
+    j["name"] = view.name;
+    j["guid"] = view.guid;
+}
+
+void from_json(const nlohmann::json& j, NavigatorView& view)
+{
+    view.name = j.at("name").get<std::string>();
+    view.guid = j.at("guid").get<std::string>();
+}

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/NavigatorView.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/NavigatorView.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "json.hpp"
+
+struct NavigatorView
+{
+    std::string name;
+    std::string guid;
+};
+
+void to_json(nlohmann::json& j, const NavigatorView& view);
+void from_json(const nlohmann::json& j, NavigatorView& view);

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/SendFilter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/SendFilter.cpp
@@ -10,6 +10,11 @@ bool SendFilter::IsArchicadElementTypeFilter()
     return typeDiscriminator == "ArchicadElementTypeFilter";
 }
 
+bool SendFilter::IsArchicadViewsFilter()
+{
+    return typeDiscriminator == "ArchicadViewsFilter";
+}
+
 ArchicadSelectionFilter SendFilter::AsArchicadSelectionFilter()
 {
     if (IsArchicadSelectionFilter())
@@ -34,6 +39,18 @@ ArchicadElementTypeFilter SendFilter::AsArchicadElementTypeFilter()
     }
 }
 
+ArchicadViewsFilter SendFilter::AsArchicadViewsFilter()
+{
+    if (IsArchicadViewsFilter())
+    {
+        return data.get<ArchicadViewsFilter>();
+    }
+    else
+    {
+        throw std::runtime_error("SendFilter is not an ArchicadViewsFilter");
+    }
+}
+
 std::vector<std::string> SendFilter::GetSelectedObjectIds()
 {
     if (IsArchicadSelectionFilter())
@@ -43,6 +60,12 @@ std::vector<std::string> SendFilter::GetSelectedObjectIds()
     else if (IsArchicadElementTypeFilter())
     {
         auto filter = AsArchicadElementTypeFilter();
+        filter.UpdateSelectedObjectIds();
+        return filter.selectedObjectIds;
+    }
+    else if (IsArchicadViewsFilter())
+    {
+        auto filter = AsArchicadViewsFilter();
         filter.UpdateSelectedObjectIds();
         return filter.selectedObjectIds;
     }

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/SendFilter.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/SendFilter.h
@@ -3,6 +3,7 @@
 #include "json.hpp"
 #include "ArchicadSelectionFilter.h"
 #include "ArchicadElementTypeFilter.h"
+#include "ArchicadViewsFilter.h"
 
 struct SendFilter
 {
@@ -11,8 +12,10 @@ struct SendFilter
 
     bool IsArchicadSelectionFilter();
     bool IsArchicadElementTypeFilter();
+    bool IsArchicadViewsFilter();
     ArchicadSelectionFilter AsArchicadSelectionFilter();
     ArchicadElementTypeFilter AsArchicadElementTypeFilter();
+    ArchicadViewsFilter AsArchicadViewsFilter();
 
     std::vector<std::string> GetSelectedObjectIds();
 };


### PR DESCRIPTION
Implements view filter in Archicad:
- the filter reuses the Revit viewsFilter from UI
- collects all 3D views from Archcad's view map
- when the user sends something with a view filter selected, then Archicad will switch to that view before the send and get the guids of all visible elements on that view