### PR TITLE
chore (archicad) Renamed Speckle Beta to Speckle

### DIFF
--- a/AddOns/Speckle/Sources/AddOnResources/RINT/AddOn.grc
+++ b/AddOns/Speckle/Sources/AddOnResources/RINT/AddOn.grc
@@ -13,12 +13,12 @@
 
 'STR#' 32500 "Menu strings" {
 /* [   ] */	"Speckle"
-/* [  1] */	"Speckle (Beta)^E3^ED^EW^ES^EE^EI^EL^ET^EM^R"
+/* [  1] */	"Speckle^E3^ED^EW^ES^EE^EI^EL^ET^EM^R"
 }
 
 /* --- Dockable browser palette ----------------------------------------------*/
 
-'GDLG'  32500    Palette | topCaption | close | grow   0   0  250  350  "Speckle (Beta)"  {
+'GDLG'  32500    Palette | topCaption | close | grow   0   0  250  350  "Speckle"  {
 /* [  1] */ Browser			0   0  250  350
 }
 


### PR DESCRIPTION
Renamed Speckle Beta to Speckle
- menu item
- browser palette title

<img width="414" alt="image" src="https://github.com/user-attachments/assets/c57c3bc6-31ee-4930-a5b3-7045783f3574" />
