### PR TITLE
fix (archicad) dont send subelement props when its turned off

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
@@ -14,7 +14,7 @@ ArchicadObject HostToSpeckleConverter::GetArchicadObject(const std::string& elem
     conversionResult.sourceType = archicadObject.type;
     conversionResult.sourceId = elemId;
 
-    archicadObject.elements = GetElementChildren(elemId);
+    archicadObject.elements = GetElementChildren(elemId, includeProperties);
     if (archicadObject.elements.empty())
     {
         archicadObject.displayValue = GetElementBody(elemId);

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
@@ -26,8 +26,8 @@ public:
 	nlohmann::json GetElementIfcProperties(const std::string& elemId) override;
 	nlohmann::json GetElementProperties(const std::string& elemId) override;
 	WorkingUnits GetWorkingUnits() override;
-	ArchicadObject GetArchicadObject(const std::string& elemId, SendConversionResult& conversionResult, bool includeProperties = true) override;
-	std::vector<ArchicadObject> GetElementChildren(const std::string& elemId, bool includeProperties = true) override;
+	ArchicadObject GetArchicadObject(const std::string& elemId, SendConversionResult& conversionResult, bool includeProperties) override;
+	std::vector<ArchicadObject> GetElementChildren(const std::string& elemId, bool includeProperties) override;
 	std::string GetResourceString(short resourceId) override;
 	std::vector<NavigatorView> GetNavigatorViews() override;
 };

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
@@ -33,8 +33,8 @@ public:
 	virtual nlohmann::json GetElementIfcProperties(const std::string& elemId) = 0;
 	virtual nlohmann::json GetElementProperties(const std::string& elemId) = 0;
 	virtual WorkingUnits GetWorkingUnits() = 0;
-	virtual ArchicadObject GetArchicadObject(const std::string& elemId, SendConversionResult& conversionResult, bool includeProperties = true) = 0;
-	virtual std::vector<ArchicadObject> GetElementChildren(const std::string& elemId, bool includeProperties = true) = 0;
+	virtual ArchicadObject GetArchicadObject(const std::string& elemId, SendConversionResult& conversionResult, bool includeProperties) = 0;
+	virtual std::vector<ArchicadObject> GetElementChildren(const std::string& elemId, bool includeProperties) = 0;
 	virtual std::string GetResourceString(short resourceId) = 0;
 	virtual std::vector<NavigatorView> GetNavigatorViews() = 0;
 };


### PR DESCRIPTION
don't send subelement properties when properties are not included in the sent settings