### PR TITLE
fix (archicad) remove views filter feature

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
@@ -58,13 +58,16 @@ void SendBridge::GetSendFilters(const RunMethodEventArgs& args)
         elementTypeFilter.availableCategories.push_back({ typeName, typeName });
     }
 
-    ArchicadViewsFilter viewsFilter;
+    // CNX-2007 
+    // ACAPI_Navigator_SearchNavigatorItem API function crashes Archicad with specific files
+    // temp remove view filters until we find a workaround or an API fix is released
+    /*ArchicadViewsFilter viewsFilter;
     for (const auto& navigatorView : CONNECTOR.GetHostToSpeckleConverter().GetNavigatorViews())
     {
         viewsFilter.availableViews.push_back(navigatorView.name);
-    }
+    }*/
 
-    auto filters = nlohmann::json::array({ selectionFilter, elementTypeFilter, viewsFilter });
+    auto filters = nlohmann::json::array({ selectionFilter, elementTypeFilter });
     args.eventSource->SetResult(args.methodId, filters);
 }
 


### PR DESCRIPTION
CNX-2007
- ACAPI_Navigator_SearchNavigatorItem API call crashes on specific files during startup
- remove view filters until a workaround is found or the API is fixed