### PR TITLE
feat(archicad): added width, height, length params to object dimensional props

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementBasicProperties.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementBasicProperties.cpp
@@ -5,6 +5,7 @@
 #include "CheckError.h"
 #include "SpeckleConversionException.h"
 #include "PropertyDefinitions.h"
+#include "JsonFileWriter.h"
 
 #include <iostream>
 
@@ -206,12 +207,17 @@ namespace
 				std::string propertyName = GetPropertyName(definition);
 				std::string propertyGroupName = GetPropertyGroupName(definition);
 				propertyJson[propertyGroupName][propertyName] = propertyValue;
+
+				// only for finding property definition ids
+				//std::string propertyId = APIGuidToString(definition.guid).ToCStr().Get();
+				//propertyJson[propertyGroupName][propertyName] = propertyId;
 			}
 			catch (const std::exception& ex)
 			{
 				std::cout << ex.what();
 			}
 		}
+		//JsonFileWriter::WriteJsonToFile(propertyJson, "C:\\t\\pro.json");
 		return propertyJson;
 	}
 }

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementProperties.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementProperties.cpp
@@ -13,8 +13,8 @@ nlohmann::json HostToSpeckleConverter::GetElementProperties(const std::string& e
 	std::vector<API_ElemTypeID> systemTypes = { API_WallID, API_SlabID, API_BeamID, API_BeamSegmentID, API_ColumnID, API_ColumnSegmentID, API_RoofID, API_ShellID, API_MorphID };
 	bool isSystemType = std::find(systemTypes.begin(), systemTypes.end(), elemType) != systemTypes.end();
 
-	std::vector<API_ElemTypeID> doorWindowStairZone = { API_DoorID, API_WindowID, API_StairID, API_ZoneID };
-	bool isDoorWindowStairZone = std::find(doorWindowStairZone.begin(), doorWindowStairZone.end(), elemType) != doorWindowStairZone.end();
+	std::vector<API_ElemTypeID> doorWindowStairZoneObject = { API_DoorID, API_WindowID, API_StairID, API_ZoneID, API_ObjectID };
+	bool isDoorWindowStairZoneObject = std::find(doorWindowStairZoneObject.begin(), doorWindowStairZoneObject.end(), elemType) != doorWindowStairZoneObject.end();
 
 	std::vector<API_ElemTypeID> compositeTypes = { API_WallID, API_SlabID, API_BeamID, API_RoofID, API_ShellID };
 	bool canBeComposite = std::find(compositeTypes.begin(), compositeTypes.end(), elemType) != compositeTypes.end();
@@ -33,7 +33,7 @@ nlohmann::json HostToSpeckleConverter::GetElementProperties(const std::string& e
 			properties["Material Quantities"] = materialQuantities;
 	}
 
-	if (isSystemType || isDoorWindowStairZone)
+	if (isSystemType || isDoorWindowStairZoneObject)
 	{
 		nlohmann::json dimensionalProperties = GetElementBuiltInProperties(elemId);
 		if (!dimensionalProperties.empty())

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/PropertyDefinitions.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/PropertyDefinitions.cpp
@@ -70,6 +70,11 @@ const std::unordered_map<API_ElemTypeID, std::vector<std::string>> PropertyDefin
         "CAF8D1EB-0BAD-48DE-AEA4-9932ECA3D913", // Zone Name
         "46ABEB73-F338-4103-AE39-0BFF099D0423", // Zone Net Perimeter
         "77367980-3D5A-452B-9900-D88C53E82176", // Zone Number
+    }},
+    { API_ObjectID, {
+        "7CAB47B5-D80B-4E2F-AB2B-71CF0BB57856", // Height
+        "DA895241-B437-4897-864C-F001FD704F64", // Length (A)
+        "19A99799-5B44-4A6F-9904-F132D7A3F0AC", // Width
     }}
 };
 


### PR DESCRIPTION
added width, height, length params to object dimensional props based on this user request:
(https://speckle.community/t/missing-length-parameter-on-gutters/20372)

<img width="1178" height="554" alt="image" src="https://github.com/user-attachments/assets/776f24b0-365f-4fed-b5ea-2a5357d083a3" />
