### PR TITLE
feat(archicad): layer filters implemented

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/Bridges/SendBridge.cpp
@@ -58,6 +58,12 @@ void SendBridge::GetSendFilters(const RunMethodEventArgs& args)
         elementTypeFilter.availableCategories.push_back({ typeName, typeName });
     }
 
+    ArchicadLayerFilter layerFilter;
+    for (const auto& layer : CONNECTOR.GetHostToSpeckleConverter().GetLayers())
+    {
+        layerFilter.availableCategories.push_back({ layer.name, layer.id });
+    }
+
     // CNX-2007 
     // ACAPI_Navigator_SearchNavigatorItem API function crashes Archicad with specific files
     // temp remove view filters until we find a workaround or an API fix is released
@@ -67,7 +73,7 @@ void SendBridge::GetSendFilters(const RunMethodEventArgs& args)
         viewsFilter.availableViews.push_back(navigatorView.name);
     }*/
 
-    auto filters = nlohmann::json::array({ selectionFilter, elementTypeFilter });
+    auto filters = nlohmann::json::array({ selectionFilter, elementTypeFilter, layerFilter });
     args.eventSource->SetResult(args.methodId, filters);
 }
 

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementList.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementList.cpp
@@ -114,6 +114,53 @@ std::vector<std::string> HostToSpeckleConverter::GetElementList(const std::vecto
 	return elementList;
 }
 
+std::vector<std::string> HostToSpeckleConverter::GetElementListByLayer(const std::vector<std::string>& layerIndices)
+{
+    std::vector<std::string> elementList;
+
+    for (const auto& elementType : GetElementTypeList())
+    {
+        auto it = stringToElementTypesMap.find(elementType);
+        if (it != stringToElementTypesMap.end())
+        {
+            auto types = it->second;
+            for (const auto& t : types)
+            {
+                try
+                {
+                    GS::Array<API_Guid> elemGuids;
+                    CHECK_ERROR(ACAPI_Element_GetElemList(t, &elemGuids));
+                    for (const auto& apiGuid : elemGuids)
+                    {
+                        API_Element element = {};
+                        element.header.guid = apiGuid;
+
+                        if (ACAPI_Element_GetHeader(&element.header) == NoError)
+                        {
+                            std::string layerIndex = element.header.layer.ToUniString().ToCStr().Get();
+                            
+                            if (std::find(layerIndices.begin(), layerIndices.end(), layerIndex) != layerIndices.end())
+                            {
+                                std::string guid = APIGuidToString(apiGuid).ToCStr().Get();
+                                elementList.push_back(guid);
+                            }
+                        }
+
+                        //std::string guid = APIGuidToString(apiGuid).ToCStr().Get();
+                        //elementList.push_back(guid);
+                    }
+                }
+                catch (const std::exception&)
+                {
+                    // continue
+                }
+            }
+        }
+    }
+
+    return elementList;
+}
+
 std::vector<std::string> HostToSpeckleConverter::GetElementTypeList()
 {
     return {

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementListByLayer.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementListByLayer.cpp
@@ -1,0 +1,31 @@
+#include "HostToSpeckleConverter.h"
+
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+#include "CheckError.h"
+
+#include <iostream>
+
+/*std::vector<std::string> HostToSpeckleConverter::GetElementListByLayer(const std::vector<int>& layerIndices)
+{	
+    std::vector<std::string> elementList;
+
+    std::cout << layerIndices.size();
+
+    try
+    {
+        GS::Array<API_Guid> elemGuids;
+        CHECK_ERROR(ACAPI_Element_GetElemList(API_ZombieElemID, &elemGuids));
+        for (const auto& apiGuid : elemGuids)
+        {
+            std::string guid = APIGuidToString(apiGuid).ToCStr().Get();
+            elementList.push_back(guid);
+        }
+    }
+    catch (const std::exception&)
+    {
+        // continue
+    }
+	
+	return elementList;
+}*/

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetLayers.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetLayers.cpp
@@ -1,0 +1,41 @@
+#include "HostToSpeckleConverter.h"
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+#include "CheckError.h"
+
+#include <iostream>
+
+std::vector<LayerData> HostToSpeckleConverter::GetLayers()
+{
+	std::vector<LayerData> layers;
+
+	GS::UInt32 layerCount;
+	CHECK_ERROR(ACAPI_Attribute_GetNum(API_LayerID, layerCount));
+
+    GSErrCode err = NoError;
+    for (UInt32 i = 1; i <= 32768; i++) 
+    {
+        API_Attribute layerAttr;
+        BNZeroMemory(&layerAttr, sizeof(API_Attribute));
+        layerAttr.header.typeID = API_LayerID;
+        layerAttr.header.index = ACAPI_CreateAttributeIndex(i);
+
+        err = ACAPI_Attribute_Get(&layerAttr);
+
+        if (err == NoError)
+        {
+            LayerData layerData;
+            GS::UniString layerName = layerAttr.header.name;
+            std::string stdLayerName = layerName.ToCStr().Get();
+            layerData.name = stdLayerName;
+            layerData.id = std::to_string(i);
+            layers.push_back(layerData);
+        }
+        else
+        {
+            std::cout << "oh";
+        }
+    }
+
+	return layers;
+}

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
@@ -9,6 +9,7 @@ public:
 
 	std::vector<std::string> GetSelection() override;
 	std::vector<std::string> GetElementList(const std::vector<std::string>& elementTypes) override;
+	std::vector<std::string> GetElementListByLayer(const std::vector<std::string>& layerIndices) override;
 	std::vector<std::string> GetElementListAllVisibleIn3D() override;
 	std::vector<std::string> GetElementTypeList() override;
 	ElementBody GetElementBody(const std::string& elemId) override;
@@ -31,4 +32,5 @@ public:
 	std::vector<ArchicadObject> GetElementChildren(const std::string& elemId, bool includeProperties) override;
 	std::string GetResourceString(short resourceId) override;
 	std::vector<NavigatorView> GetNavigatorViews() override;
+	std::vector<LayerData> GetLayers() override;
 };

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
@@ -9,6 +9,7 @@
 #include "PropertyFilters.h"
 #include "NavigatorView.h"
 #include "ArchicadLevel.h"
+#include "LayerData.h"
 
 class IHostToSpeckleConverter 
 {
@@ -17,6 +18,7 @@ public:
 
 	virtual std::vector<std::string> GetSelection() = 0;
 	virtual std::vector<std::string> GetElementList(const std::vector<std::string>& elementTypes) = 0;
+	virtual std::vector<std::string> GetElementListByLayer(const std::vector<std::string>& layerIndices) = 0;
 	virtual std::vector<std::string> GetElementListAllVisibleIn3D() = 0;
 	virtual std::vector<std::string> GetElementTypeList() = 0;
 	virtual ElementBody GetElementBody(const std::string& elemId) = 0;
@@ -39,4 +41,5 @@ public:
 	virtual std::vector<ArchicadObject> GetElementChildren(const std::string& elemId, bool includeProperties) = 0;
 	virtual std::string GetResourceString(short resourceId) = 0;
 	virtual std::vector<NavigatorView> GetNavigatorViews() = 0;
+	virtual std::vector<LayerData> GetLayers() = 0;
 };

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ISpeckleToHostConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ISpeckleToHostConverter.h
@@ -14,6 +14,7 @@ public:
 	virtual void SetSelection(std::vector<std::string> guids) = 0;
 	virtual void ShowAllIn3D() = 0;
 	virtual void ShowIn3D() = 0;
+	virtual void ShowLayers(const std::vector<int>& layerIndices) = 0;
 	virtual void SetView(const std::string& viewName) = 0;
 	virtual int CreateMaterial(const Material& material, const std::string& baseGroupName) = 0;
 	virtual int CreateMaterial(const ColorProxy& color, const std::string& baseGroupName) = 0;

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ShowAllIn3D.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/ShowAllIn3D.cpp
@@ -3,6 +3,7 @@
 #include "APIEnvir.h"
 #include "ACAPinc.h"
 #include "CheckError.h"
+#include <iostream>
 
 void SpeckleToHostConverter::ShowAllIn3D()
 {
@@ -18,5 +19,25 @@ void SpeckleToHostConverter::ShowIn3D()
 		API_WindowInfo newWindowInfo = {};
 		newWindowInfo.typeID = APIWind_3DModelID;
 		CHECK_ERROR(ACAPI_Window_ChangeWindow(&newWindowInfo));
+	}
+}
+
+void SpeckleToHostConverter::ShowLayers(const std::vector<int>& layerIndices)
+{
+	for (const auto i : layerIndices)
+	{
+		API_Attribute layerAttr;
+		BNZeroMemory(&layerAttr, sizeof(API_Attribute));
+		layerAttr.header.typeID = API_LayerID;
+		layerAttr.header.index = ACAPI_CreateAttributeIndex(i);
+
+		GSErrCode err = NoError;
+		err = ACAPI_Attribute_Get(&layerAttr);
+
+		if (err == NoError)
+		{
+			layerAttr.layer.head.flags = 0;
+			ACAPI_Attribute_Modify(&layerAttr, nullptr);
+		}
 	}
 }

--- a/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SpeckleToHostConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/SpeckleToHost/SpeckleToHostConverter.h
@@ -10,6 +10,7 @@ public:
 	void SetSelection(std::vector<std::string> guids) override;
 	void ShowAllIn3D() override;
 	void ShowIn3D() override;
+	void ShowLayers(const std::vector<int>& layerIndices) override;
 	void SetView(const std::string& viewName) override;
 	int CreateMaterial(const Material& material, const std::string& materialName) override;
 	int CreateMaterial(const ColorProxy& color, const std::string& materialName) override;

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadLayerFilter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadLayerFilter.cpp
@@ -1,0 +1,38 @@
+#include "ArchicadLayerFilter.h"
+#include "Connector.h"
+
+void to_json(nlohmann::json& j, const ArchicadLayerFilter& filter)
+{
+    j["typeDiscriminator"] = filter.typeDiscriminator;
+    j["selectedObjectIds"] = filter.selectedObjectIds;
+    j["name"] = filter.name;
+    j["id"] = filter.id;
+    j["summary"] = filter.summary;
+    j["isDefault"] = filter.isDefault;
+    j["selectedCategories"] = filter.selectedCategories;
+    j["availableCategories"] = filter.availableCategories;
+}
+
+void from_json(const nlohmann::json& j, ArchicadLayerFilter& filter)
+{
+    filter.typeDiscriminator = j.at("typeDiscriminator").get<std::string>();
+    filter.selectedObjectIds = j.at("selectedObjectIds").get<std::vector<std::string>>();
+    filter.name = j.at("name").get<std::string>();
+    filter.id = j.at("id").get<std::string>();
+    filter.summary = j.at("summary").get<std::string>();
+    filter.isDefault = j.at("isDefault").get<bool>();
+    filter.selectedCategories = j.at("selectedCategories").get<std::vector<std::string>>();
+    filter.availableCategories = j.at("availableCategories").get<std::vector<CategoryData>>();
+}
+
+void ArchicadLayerFilter::UpdateSelectedObjectIds()
+{
+    std::vector<int> selectedCategoriesInt;
+    std::transform(selectedCategories.begin(), selectedCategories.end(),
+        std::back_inserter(selectedCategoriesInt),
+        [](const std::string& str) { return std::stoi(str); });
+
+    CONNECTOR.GetSpeckleToHostConverter().ShowLayers(selectedCategoriesInt);
+
+    selectedObjectIds = CONNECTOR.GetHostToSpeckleConverter().GetElementListByLayer(selectedCategories);
+}

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadLayerFilter.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadLayerFilter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "json.hpp"
+#include "CategoryData.h"
+
+struct ArchicadLayerFilter
+{
+    std::string typeDiscriminator = "ArchicadLayerFilter";
+    std::vector<std::string> selectedObjectIds;
+    std::string name = "Layers";
+    // revitCategories was first implemented on UI
+    // it will be used in Archicad as well for element type filters
+    std::string id = "revitCategories";
+    std::string summary;
+    bool isDefault = false;
+    std::vector<std::string> selectedCategories;
+    std::vector<CategoryData> availableCategories;
+
+    void UpdateSelectedObjectIds();
+};
+
+void to_json(nlohmann::json& j, const ArchicadLayerFilter& filter);
+void from_json(const nlohmann::json& j, ArchicadLayerFilter& filter);

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/CategoryData.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/CategoryData.h
@@ -9,5 +9,5 @@ struct CategoryData
     std::string id;
 };
 
-void to_json(nlohmann::json& j, const CategoryData& level);
-void from_json(const nlohmann::json& j, CategoryData& level);
+void to_json(nlohmann::json& j, const CategoryData& data);
+void from_json(const nlohmann::json& j, CategoryData& data);

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/LayerData.cpp
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/LayerData.cpp
@@ -1,0 +1,13 @@
+#include "LayerData.h"
+
+void to_json(nlohmann::json& j, const LayerData& data)
+{
+    j["name"] = data.name;
+    j["id"] = data.id;
+}
+
+void from_json(const nlohmann::json& j, LayerData& data)
+{
+    data.name = j.at("name").get<std::string>();
+    data.id = j.at("id").get<std::string>();
+}

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/LayerData.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/LayerData.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "json.hpp"
+
+
+struct LayerData
+{
+    std::string name;
+    std::string id;
+};
+
+void to_json(nlohmann::json& j, const LayerData& data);
+void from_json(const nlohmann::json& j, LayerData& data);

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/SendFilter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/SendFilter.cpp
@@ -15,6 +15,11 @@ bool SendFilter::IsArchicadViewsFilter()
     return typeDiscriminator == "ArchicadViewsFilter";
 }
 
+bool SendFilter::IsArchicadLayerFilter()
+{
+    return typeDiscriminator == "ArchicadLayerFilter";
+}
+
 ArchicadSelectionFilter SendFilter::AsArchicadSelectionFilter()
 {
     if (IsArchicadSelectionFilter())
@@ -51,6 +56,18 @@ ArchicadViewsFilter SendFilter::AsArchicadViewsFilter()
     }
 }
 
+ArchicadLayerFilter SendFilter::AsArchicadLayerFilter()
+{
+    if (IsArchicadLayerFilter())
+    {
+        return data.get<ArchicadLayerFilter>();
+    }
+    else
+    {
+        throw std::runtime_error("SendFilter is not an ArchicadLayerFilter");
+    }
+}
+
 std::vector<std::string> SendFilter::GetSelectedObjectIds()
 {
     if (IsArchicadSelectionFilter())
@@ -66,6 +83,12 @@ std::vector<std::string> SendFilter::GetSelectedObjectIds()
     else if (IsArchicadViewsFilter())
     {
         auto filter = AsArchicadViewsFilter();
+        filter.UpdateSelectedObjectIds();
+        return filter.selectedObjectIds;
+    }
+    else if (IsArchicadLayerFilter())
+    {
+        auto filter = AsArchicadLayerFilter();
         filter.UpdateSelectedObjectIds();
         return filter.selectedObjectIds;
     }

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/SendFilter.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/SendFilter.h
@@ -4,6 +4,7 @@
 #include "ArchicadSelectionFilter.h"
 #include "ArchicadElementTypeFilter.h"
 #include "ArchicadViewsFilter.h"
+#include "ArchicadLayerFilter.h"
 
 struct SendFilter
 {
@@ -13,9 +14,11 @@ struct SendFilter
     bool IsArchicadSelectionFilter();
     bool IsArchicadElementTypeFilter();
     bool IsArchicadViewsFilter();
+    bool IsArchicadLayerFilter();
     ArchicadSelectionFilter AsArchicadSelectionFilter();
     ArchicadElementTypeFilter AsArchicadElementTypeFilter();
     ArchicadViewsFilter AsArchicadViewsFilter();
+    ArchicadLayerFilter AsArchicadLayerFilter();
 
     std::vector<std::string> GetSelectedObjectIds();
 };


### PR DESCRIPTION
- Layer Filters implemented
- Similar to Revit category filter -> multiselect
- If the user adds a layer to the filter, but it's hidden in AC, then we will make it visible before send, else we cannot get the geometries from AC

<img width="329" height="334" alt="image" src="https://github.com/user-attachments/assets/2b1b14fc-27a6-4ada-b573-8333a5a63d47" />

