### PR TITLE
ci: Prepare for Calendar release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,12 +18,13 @@ jobs:
     runs-on: windows-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Build
         run: ./build.ps1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,9 +6,8 @@
 name: Build Archicad
 
 on:
-  pull_request: # Run build on every pull request that is not to main
-    branches-ignore:
-      - main
+  pull_request:
+
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ name: Build and Deploy Archicad
 
 on:
   push:
-    branches: ["main", "installer-test/**"] # Continuous delivery on every long-lived branch
-    tags: ["v3.*.*"] # Manual delivery on every 3.x tag
+    branches: ["installer-test/**"]
+    tags: ["v202*.*.*"]
 
 jobs:
   build-windows:
@@ -18,12 +18,13 @@ jobs:
       file_version: ${{ steps.set-info-version.outputs.file_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: ⚒️ Run GitVersion
         run: ./build.ps1 build-server-version
@@ -31,7 +32,7 @@ jobs:
       - name: Build
         run: ./build.ps1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: output-${{ env.GitVersion_FullSemVer }}
           path: output/*.zip
@@ -52,7 +53,7 @@ jobs:
       IS_PUBLIC_RELEASE: ${{ github.ref_type == 'tag' }}
     steps:
       - name: 🔫 Trigger Build Installer(s)
-        uses: the-actions-org/workflow-dispatch@v4.0.0
+        uses: benc-uk/workflow-dispatch@v1.3.2
         with:
           workflow: Build Installers
           repo: specklesystems/connector-installers
@@ -66,11 +67,9 @@ jobs:
             }'
           ref: main
           wait-for-completion: true
-          wait-for-completion-interval: 10s
-          wait-for-completion-timeout: 10m
-          display-workflow-run-url: true
-          display-workflow-run-url-interval: 10s
+          sync-status: true
+        timeout-minutes: 15
 
-      - uses: geekyeggo/delete-artifact@v5
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: output-*

--- a/ci-build/Consts.cs
+++ b/ci-build/Consts.cs
@@ -2,18 +2,37 @@
 
 public static class Consts
 {
-  public static readonly string[] SupportedVersions = new string[] { "27", "28", "29"};
-  public static readonly string[] Solutions = ["build_27/speckle-archicad.sln", "build_28/speckle-archicad.sln", "build_29/speckle-archicad.sln"];
+    public static readonly string[] SupportedVersions = new string[] { "27", "28", "29" };
+    public static readonly string[] Solutions =
+    [
+        "build_27/speckle-archicad.slnx",
+        "build_28/speckle-archicad.slnx",
+        "build_29/speckle-archicad.slnx",
+    ];
 
-  public static readonly InstallerProject[] InstallerManifests =
-  {
-    new("archicad", [new("archicad27", "build/27/INT/Release", "*.apx"), new("archicad28", "build/28/INT/Release", "*.apx"), new("archicad29", "build/29/INT/Release", "*.apx")])
-  };
+    public static readonly InstallerProject[] InstallerManifests =
+    {
+        new(
+            "archicad",
+            [
+                new("archicad27", "build/27/INT/Release", "*.apx"),
+                new("archicad28", "build/28/INT/Release", "*.apx"),
+                new("archicad29", "build/29/INT/Release", "*.apx"),
+            ]
+        ),
+    };
 }
 
-public readonly record struct InstallerProject(string HostAppSlug, IReadOnlyList<InstallerAsset> Projects)
+public readonly record struct InstallerProject(
+    string HostAppSlug,
+    IReadOnlyList<InstallerAsset> Projects
+)
 {
-  public override string ToString() => $"{HostAppSlug}";
+    public override string ToString() => $"{HostAppSlug}";
 }
 
-public readonly record struct InstallerAsset(string ConnectorVersion, string OutputPath, string GlobPattern = "*");
+public readonly record struct InstallerAsset(
+    string ConnectorVersion,
+    string OutputPath,
+    string GlobPattern = "*"
+);

--- a/ci-build/Program.cs
+++ b/ci-build/Program.cs
@@ -1,9 +1,9 @@
 using System.IO.Compression;
+using System.Reflection;
 using Build;
 using GlobExpressions;
 using static Bullseye.Targets;
 using static SimpleExec.Command;
-using System.Reflection;
 
 const string CLEAN = "clean";
 const string BUILD = "build";
@@ -13,130 +13,166 @@ const string BUILD_SERVER_VERSION = "build-server-version";
 const string RUN_CMAKE = "build-cmake";
 
 Target(
-  CLEAN,
-  ForEach("**/output"),
-  dir =>
-  {
-    IEnumerable<string> GetDirectories(string d)
+    CLEAN,
+    ForEach("**/output"),
+    dir =>
     {
-      return Glob.Directories(".", d);
-    }
-
-    void RemoveDirectory(string d)
-    {
-      if (Directory.Exists(d))
-      {
-        Console.WriteLine(d);
-        Directory.Delete(d, true);
-      }
-    }
-
-    foreach (var d in GetDirectories(dir))
-    {
-      RemoveDirectory(d);
-    }
-  }
-);
-
-Target(
-  RESTORE_TOOLS,
-  () =>
-  {
-    Run("dotnet", "tool restore");
-  }
-);
-
-Target(
-  BUILD_SERVER_VERSION,
-  DependsOn(RESTORE_TOOLS),
-  () =>
-  {
-    Run("dotnet", "tool run dotnet-gitversion /output json /output buildserver");
-  }
-);
-
-Target(RUN_CMAKE, Consts.SupportedVersions, s =>
-{
-  var toolset = s == "29" ? "v143" : "v142";
-  Run("cmake", $"-G \"Visual Studio 18 2026\" -T {toolset} -A \"x64\" -DAC_ADDON_LANGUAGE=\"INT\" -DAC_API_DEVKIT_DIR=\"Libs\\acapi{s}\" -B build\\{s} -DCMAKE_BUILD_TYPE=Release");
-});
-
-Target(
-  BUILD,
-  DependsOn(RUN_CMAKE),
-  Consts.SupportedVersions,
-  s =>
-  {
-    var version = Environment.GetEnvironmentVariable("GitVersion_FullSemVer") ?? "3.0.0-localBuild";
-    var fileVersion = Environment.GetEnvironmentVariable("GitVersion_AssemblySemFileVer") ?? "3.0.0.9999";
-    Console.WriteLine($"Version: {version} & {fileVersion}");
-	
-	void ReplaceStringInFile(string filePath, string targetString, string replacementString)
-    {
-        try
+        IEnumerable<string> GetDirectories(string d)
         {
-            string fileContent = File.ReadAllText(filePath);
-            string updatedContent = fileContent.Replace(targetString, replacementString);
-            File.WriteAllText(filePath, updatedContent);
-
-            Console.WriteLine("Replacement successful.");
+            return Glob.Directories(".", d);
         }
-        catch (Exception ex)
+
+        void RemoveDirectory(string d)
         {
-            Console.WriteLine($"An error occurred: {ex.Message}");
+            if (Directory.Exists(d))
+            {
+                Console.WriteLine(d);
+                Directory.Delete(d, true);
+            }
+        }
+
+        foreach (var d in GetDirectories(dir))
+        {
+            RemoveDirectory(d);
         }
     }
-	
-	string assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-	string archicadResourcefilePath = Path.Combine(assemblyDir, "..", "..", "..", "..", "AddOns", "Speckle", "Sources", "AddOnResources", "RINT", "AddOn.grc");
-	ReplaceStringInFile(archicadResourcefilePath, "connector_build_num", version);
-	
-    Run("msbuild", $"./build/{s}/archicad-speckle.sln /p:Configuration=Release /p:Version={version} /p:FileVersion={fileVersion}");
-  }
 );
 
 Target(
-  ZIP,
-  DependsOn(BUILD),
-  Consts.InstallerManifests,
-  x =>
-  {
-    var outputDir = Path.Combine(".", "output");
-    var slugDir = Path.Combine(outputDir, x.HostAppSlug);
-
-    Directory.CreateDirectory(outputDir);
-    Directory.CreateDirectory(slugDir);
-
-    foreach (var asset in x.Projects)
+    RESTORE_TOOLS,
+    () =>
     {
-      var fullPath = Path.Combine(".", asset.OutputPath);
-      if (!Directory.Exists(fullPath))
-      {
-        throw new InvalidOperationException("Could not find: " + fullPath);
-      }
-
-      var assetName = asset.ConnectorVersion;
-      var connectorDir = Path.Combine(slugDir, assetName);
-      Directory.CreateDirectory(connectorDir);
-      foreach (var directory in Directory.EnumerateDirectories(fullPath, asset.GlobPattern, SearchOption.AllDirectories))
-      {
-        Directory.CreateDirectory(directory.Replace(fullPath, connectorDir));
-      }
-
-      foreach (var file in Directory.EnumerateFiles(fullPath, asset.GlobPattern, SearchOption.AllDirectories))
-      {
-        Console.WriteLine(file);
-        var destFileName = file.Replace(fullPath, connectorDir);
-        File.Copy(file, destFileName, true);
-      }
+        Run("dotnet", "tool restore");
     }
+);
 
-    var outputPath = Path.Combine(outputDir, $"{x.HostAppSlug}.zip");
-    File.Delete(outputPath);
-    Console.WriteLine($"Zipping: '{slugDir}' to '{outputPath}'");
-    ZipFile.CreateFromDirectory(slugDir, outputPath);
-    // Directory.Delete(slugDir, true);
-  }
+Target(
+    BUILD_SERVER_VERSION,
+    DependsOn(RESTORE_TOOLS),
+    () =>
+    {
+        Run("dotnet", "tool run dotnet-gitversion /output json /output buildserver");
+    }
+);
+
+Target(
+    RUN_CMAKE,
+    Consts.SupportedVersions,
+    s =>
+    {
+        var toolset = s == "29" ? "v143" : "v142";
+        Run(
+            "cmake",
+            $"-G \"Visual Studio 18 2026\" -T {toolset} -A \"x64\" -DAC_ADDON_LANGUAGE=\"INT\" -DAC_API_DEVKIT_DIR=\"Libs\\acapi{s}\" -B build\\{s} -DCMAKE_BUILD_TYPE=Release"
+        );
+    }
+);
+
+Target(
+    BUILD,
+    DependsOn(RUN_CMAKE),
+    Consts.SupportedVersions,
+    s =>
+    {
+        var version =
+            Environment.GetEnvironmentVariable("GitVersion_FullSemVer") ?? "3.0.0-localBuild";
+        var fileVersion =
+            Environment.GetEnvironmentVariable("GitVersion_AssemblySemFileVer") ?? "3.0.0.9999";
+        Console.WriteLine($"Version: {version} & {fileVersion}");
+
+        void ReplaceStringInFile(string filePath, string targetString, string replacementString)
+        {
+            try
+            {
+                string fileContent = File.ReadAllText(filePath);
+                string updatedContent = fileContent.Replace(targetString, replacementString);
+                File.WriteAllText(filePath, updatedContent);
+
+                Console.WriteLine("Replacement successful.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An error occurred: {ex.Message}");
+            }
+        }
+
+        string assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        string archicadResourcefilePath = Path.Combine(
+            assemblyDir,
+            "..",
+            "..",
+            "..",
+            "..",
+            "AddOns",
+            "Speckle",
+            "Sources",
+            "AddOnResources",
+            "RINT",
+            "AddOn.grc"
+        );
+        ReplaceStringInFile(archicadResourcefilePath, "connector_build_num", version);
+
+        Run(
+            "msbuild",
+            $"./build/{s}/archicad-speckle.slnx /p:Configuration=Release /p:Version={version} /p:FileVersion={fileVersion}"
+        );
+    }
+);
+
+Target(
+    ZIP,
+    DependsOn(BUILD),
+    Consts.InstallerManifests,
+    x =>
+    {
+        var outputDir = Path.Combine(".", "output");
+        var slugDir = Path.Combine(outputDir, x.HostAppSlug);
+
+        Directory.CreateDirectory(outputDir);
+        Directory.CreateDirectory(slugDir);
+
+        foreach (var asset in x.Projects)
+        {
+            var fullPath = Path.Combine(".", asset.OutputPath);
+            if (!Directory.Exists(fullPath))
+            {
+                throw new InvalidOperationException("Could not find: " + fullPath);
+            }
+
+            var assetName = asset.ConnectorVersion;
+            var connectorDir = Path.Combine(slugDir, assetName);
+            Directory.CreateDirectory(connectorDir);
+            foreach (
+                var directory in Directory.EnumerateDirectories(
+                    fullPath,
+                    asset.GlobPattern,
+                    SearchOption.AllDirectories
+                )
+            )
+            {
+                Directory.CreateDirectory(directory.Replace(fullPath, connectorDir));
+            }
+
+            foreach (
+                var file in Directory.EnumerateFiles(
+                    fullPath,
+                    asset.GlobPattern,
+                    SearchOption.AllDirectories
+                )
+            )
+            {
+                Console.WriteLine(file);
+                var destFileName = file.Replace(fullPath, connectorDir);
+                File.Copy(file, destFileName, true);
+            }
+        }
+
+        var outputPath = Path.Combine(outputDir, $"{x.HostAppSlug}.zip");
+        File.Delete(outputPath);
+        Console.WriteLine($"Zipping: '{slugDir}' to '{outputPath}'");
+        ZipFile.CreateFromDirectory(slugDir, outputPath);
+        // Directory.Delete(slugDir, true);
+    }
 );
 
 Target("default", DependsOn(ZIP), () => Console.WriteLine("Done!"));

--- a/ci-build/Program.cs
+++ b/ci-build/Program.cs
@@ -58,7 +58,7 @@ Target(
 Target(RUN_CMAKE, Consts.SupportedVersions, s =>
 {
   var toolset = s == "29" ? "v143" : "v142";
-  Run("cmake", $"-G \"Visual Studio 17 2022\" -T {toolset} -A \"x64\" -DAC_ADDON_LANGUAGE=\"INT\" -DAC_API_DEVKIT_DIR=\"Libs\\acapi{s}\" -B build\\{s} -DCMAKE_BUILD_TYPE=Release");
+  Run("cmake", $"-G \"Visual Studio 18 2026\" -T {toolset} -A \"x64\" -DAC_ADDON_LANGUAGE=\"INT\" -DAC_API_DEVKIT_DIR=\"Libs\\acapi{s}\" -B build\\{s} -DCMAKE_BUILD_TYPE=Release");
 });
 
 Target(

--- a/generate_project_27.bat
+++ b/generate_project_27.bat
@@ -1,1 +1,1 @@
-cmake -G "Visual Studio 17 2022" -T v142 -A "x64" -DAC_ADDON_LANGUAGE="INT" -DAC_API_DEVKIT_DIR="Libs\acapi27" -B build_27 -DCMAKE_BUILD_TYPE=Debug
+cmake -G "Visual Studio 18 2026" -T v142 -A "x64" -DAC_ADDON_LANGUAGE="INT" -DAC_API_DEVKIT_DIR="Libs\acapi27" -B build_27 -DCMAKE_BUILD_TYPE=Debug

--- a/generate_project_28.bat
+++ b/generate_project_28.bat
@@ -1,1 +1,1 @@
-cmake -G "Visual Studio 17 2022" -T v142 -A "x64" -DAC_ADDON_LANGUAGE="INT" -DAC_API_DEVKIT_DIR="Libs\acapi28" -B build_28 -DCMAKE_BUILD_TYPE=Debug
+cmake -G "Visual Studio 18 2026" -T v142 -A "x64" -DAC_ADDON_LANGUAGE="INT" -DAC_API_DEVKIT_DIR="Libs\acapi28" -B build_28 -DCMAKE_BUILD_TYPE=Debug

--- a/generate_project_29.bat
+++ b/generate_project_29.bat
@@ -1,1 +1,1 @@
-cmake -G "Visual Studio 17 2022" -A "x64" -DAC_ADDON_LANGUAGE="INT" -DAC_API_DEVKIT_DIR="Libs\acapi29" -B build_29 -DCMAKE_BUILD_TYPE=Debug
+cmake -G "Visual Studio 18 2026" -T v143 -A "x64" -DAC_ADDON_LANGUAGE="INT" -DAC_API_DEVKIT_DIR="Libs\acapi29" -B build_29 -DCMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
- changed release workflow to trigger on calendar tags
- Bump to avoid deprecated node 20 cuttoff
- Migrated build scripts to VS 2026 since VS 2022 is no longer available on windows images