### PR TITLE
ci: Replace gitversion with simpler tag parsing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Add MSBuild to PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,37 +15,43 @@ jobs:
     runs-on: windows-latest
     outputs:
       semver: ${{ steps.set-version.outputs.semver }}
-      file_version: ${{ steps.set-info-version.outputs.file_version }}
+      file_version: ${{ steps.set-version.outputs.file_version }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v3
 
-      - name: ⚒️ Run GitVersion
-        run: ./build.ps1 build-server-version
+      - id: set-version
+        name: Set version to output
+        run: |
+          TAG=${{ github.ref_name }}
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            TAG="0.0.0.${{ github.run_number }}"
+          fi
+          SEMVER="${TAG}"
+          FILE_VERSION=$(echo "$TAG" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          FILE_VERSION="$FILE_VERSION.${{ github.run_number }}"
+
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+          echo "fileVersion=$FILE_VERSION" >> "$GITHUB_OUTPUT"
+
+          echo $SEMVER
+          echo $FILE_VERSION
 
       - name: Build
         run: ./build.ps1
 
       - uses: actions/upload-artifact@v7
         with:
-          name: output-${{ env.GitVersion_FullSemVer }}
+          name: output-${{ steps.set-version.outputs.semver }}
           path: output/*.zip
           retention-days: 1
           if-no-files-found: error
 
-      - id: set-version
-        name: Set version to output
-        run: echo "semver=${{ env.GitVersion_FullSemVer }}" >> "$Env:GITHUB_OUTPUT"
-
-      - id: set-info-version
-        name: Set file version to output
-        run: echo "file_version=${{ env.GitVersion_AssemblySemVer}}" >> "$Env:GITHUB_OUTPUT" # version will be retrieved from tag?
   deploy-installers:
     runs-on: ubuntu-latest
     needs: build-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     outputs:
       semver: ${{ steps.set-version.outputs.semver }}
-      file_version: ${{ steps.set-version.outputs.file_version }}
+      fileVersion: ${{ steps.set-version.outputs.fileVersion }}
 
     steps:
       - uses: actions/checkout@v7
@@ -68,7 +68,7 @@ jobs:
           inputs: '{
             "run_id": "${{ github.run_id }}",
             "semver": "${{ needs.build-windows.outputs.semver }}",
-            "file_version": "${{needs.build-windows.outputs.file_version}}",
+            "file_version": "${{needs.build-windows.outputs.fileVersion}}",
             "repo": "${{ github.repository }}",
             "is_public_release": ${{ env.IS_PUBLIC_RELEASE }}
             }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
       - id: set-version
         name: Set version to output
+        shell: bash
         run: |
           TAG=${{ github.ref_name }}
           if [[ "${{ github.ref }}" != refs/tags/* ]]; then

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,0 @@
-workflow: GitFlow/v1
-next-version: 3.0.0
-branches:
-  release:
-    prevent-increment:
-      when-current-commit-tagged: true

--- a/ci-build/Program.cs
+++ b/ci-build/Program.cs
@@ -9,7 +9,6 @@ const string CLEAN = "clean";
 const string BUILD = "build";
 const string ZIP = "zip";
 const string RESTORE_TOOLS = "restore-tools";
-const string BUILD_SERVER_VERSION = "build-server-version";
 const string RUN_CMAKE = "build-cmake";
 
 Target(
@@ -47,15 +46,6 @@ Target(
 );
 
 Target(
-    BUILD_SERVER_VERSION,
-    DependsOn(RESTORE_TOOLS),
-    () =>
-    {
-        Run("dotnet", "tool run dotnet-gitversion /output json /output buildserver");
-    }
-);
-
-Target(
     RUN_CMAKE,
     Consts.SupportedVersions,
     s =>
@@ -74,10 +64,8 @@ Target(
     Consts.SupportedVersions,
     s =>
     {
-        var version =
-            Environment.GetEnvironmentVariable("GitVersion_FullSemVer") ?? "3.0.0-localBuild";
-        var fileVersion =
-            Environment.GetEnvironmentVariable("GitVersion_AssemblySemFileVer") ?? "3.0.0.9999";
+        var version = Environment.GetEnvironmentVariable("SEMVER") ?? "0.0.0-localBuild";
+        var fileVersion = Environment.GetEnvironmentVariable("FILE_VERSION") ?? "0.0.0.9999";
         Console.WriteLine($"Version: {version} & {fileVersion}");
 
         void ReplaceStringInFile(string filePath, string targetString, string replacementString)


### PR DESCRIPTION
Replace gitversion with the same tag based parsing logic we have in other repos.
All other repos we transitioned away from using gitversion years ago, but this repo was neglected

What this means:
 - no more `dev` or `releases/3.0.0` branches, we'll just make squash PRs to `main` like in other repos  
 - Releases made via tags (as before)