### PR TITLE
ci: fix for `v` prefixing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
         run: |
           TAG=${{ github.ref_name }}
           if [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            TAG="0.0.0.${{ github.run_number }}"
+            TAG="v0.0.0.${{ github.run_number }}"
           fi
-          SEMVER="${TAG}"
-          FILE_VERSION=$(echo "$TAG" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          SEMVER="${TAG#v}"
+          FILE_VERSION=$(echo "$TAG" | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
           FILE_VERSION="$FILE_VERSION.${{ github.run_number }}"
 
           echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Small tweak to allow tags to be prefixed with a `v` to match the existing convention in this repo