### PR TITLE
fix(ci): ship duckdb.dll in the installer zips

### DIFF
--- a/ci-build/Consts.cs
+++ b/ci-build/Consts.cs
@@ -16,8 +16,12 @@ public static class Consts
             "archicad",
             [
                 new("archicad27", "build/27/INT/Release", "*.apx"),
+                // duckdb.dll is delay-loaded by the add-on and must ship next to the .apx
+                new("archicad27", "build/27/INT/Release", "duckdb.dll"),
                 new("archicad28", "build/28/INT/Release", "*.apx"),
+                new("archicad28", "build/28/INT/Release", "duckdb.dll"),
                 new("archicad29", "build/29/INT/Release", "*.apx"),
+                new("archicad29", "build/29/INT/Release", "duckdb.dll"),
             ]
         ),
     };


### PR DESCRIPTION
## Problem

The `zip` target's installer manifest (`ci-build/Consts.cs`) globs `*.apx` only. The CMake post-build step copies the delay-loaded `duckdb.dll` next to the `.apx` in `build/{27,28,29}/INT/Release`, but the zip step filtered it out — so no packaged installer ever shipped the DLL.

Impact on shipped builds:
- **Receive was completely broken** — the native artefact receive requires DuckDB and has no fallback path, so every receive failed with "Could not load duckdb.dll from the add-on folder".
- Artefact send silently failed over the same way; only classic browser send survived (thanks to `/DELAYLOAD`).

## Fix

Add a `duckdb.dll` asset entry per Archicad version alongside the existing `*.apx` entry. Both entries share the same connector-version slug, so the zip logic copies them into the same folder — the DLL lands next to the `.apx`, which is the layout `DuckDbRuntime::EnsureLoaded` expects.

## Verification

`dotnet build ci-build/build.csproj` compiles clean (the two nullability warnings are pre-existing). Found during the big-truck regression review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)