### PR TITLE
Preserve array-valued properties in the artifact bundle

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
@@ -107,6 +107,27 @@ namespace
         return v.is_boolean() || v.is_string() || v.is_number();
     }
 
+    // Joins an array's scalar elements into one comma-separated string, reusing the
+    // same String(value) text as scalar rows. Null / non-scalar elements are skipped
+    // (Archicad property arrays are always scalar-valued in practice). Returns "" for
+    // an empty or all-non-scalar array so the caller can drop it instead of emitting a
+    // blank row.
+    std::string JoinArrayScalars(const nlohmann::json& arr)
+    {
+        std::string out;
+        bool first = true;
+        for (const auto& el : arr)
+        {
+            if (el.is_null() || !IsScalar(el))
+                continue;
+            if (!first)
+                out += ", ";
+            out += ToText(el);
+            first = false;
+        }
+        return out;
+    }
+
     std::string EscapeSqlLiteral(const std::string& s)
     {
         std::string out;
@@ -363,8 +384,26 @@ void BundleWriter::WalkProperties(int objectK, const nlohmann::json& obj, const 
         }
 
         if (IsScalar(val))
+        {
             AddEavRow(objectK, path, val, nullptr, nullptr);
-        // arrays / other non-scalars are skipped, matching the SDK's walk
+            continue;
+        }
+
+        if (val.is_array())
+        {
+            // Archicad — unlike Revit, which the SDK's array-skipping walk was shaped
+            // around — emits genuinely multi-valued properties as JSON arrays (native
+            // List / Multiple-Choice Enumeration collection types, and IFC List /
+            // Enumerated properties). The EAV model is one value per row, so we collapse
+            // the elements into a single comma-separated string to preserve them rather
+            // than drop the whole property. (IFC bounded ranges are split into lower/upper
+            // rows upstream, so they never reach here as an array.)
+            const std::string joined = JoinArrayScalars(val);
+            if (!joined.empty())
+                AddEavRow(objectK, path, nlohmann::json(joined), nullptr, nullptr);
+            continue;
+        }
+        // remaining non-scalars (nested arrays, objects without name/value) are skipped
     }
 }
 

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementIfcProperties.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementIfcProperties.cpp
@@ -79,11 +79,14 @@ namespace
 		return values;
 	}
 
-	std::pair<nlohmann::json, nlohmann::json> GetIfcBoundedPropertyValue(const IFCAPI::PropertyBoundedValue& propertyBoundedValue)
+	// A bounded value is a lower/upper range, not a list — emit it as a keyed object so
+	// the EAV flattener stores each bound as its own row (properties.<pset>.<name>.lower
+	// / .upper) instead of an array, which the property walk would otherwise drop.
+	nlohmann::json GetIfcBoundedPropertyValue(const IFCAPI::PropertyBoundedValue& propertyBoundedValue)
 	{
-		std::pair<nlohmann::json, nlohmann::json> values;
-		values.first = GetIfcPropertyValue(propertyBoundedValue.GetLowerBoundValue());
-		values.second = GetIfcPropertyValue(propertyBoundedValue.GetUpperBoundValue());
+		nlohmann::json values;
+		values["lower"] = GetIfcPropertyValue(propertyBoundedValue.GetLowerBoundValue());
+		values["upper"] = GetIfcPropertyValue(propertyBoundedValue.GetUpperBoundValue());
 
 		return values;
 	}
@@ -246,11 +249,14 @@ namespace
 		return values;
 	}
 
-	std::pair<nlohmann::json, nlohmann::json> GetIfcBoundedPropertyValue(const API_IFCProperty& property)
+	// A bounded value is a lower/upper range, not a list — emit it as a keyed object so
+	// the EAV flattener stores each bound as its own row (properties.<pset>.<name>.lower
+	// / .upper) instead of an array, which the property walk would otherwise drop.
+	nlohmann::json GetIfcBoundedPropertyValue(const API_IFCProperty& property)
 	{
-		std::pair<nlohmann::json, nlohmann::json> values;
-		values.first = GetIfcPropertyValue(property.boundedValue.lowerBoundValue);
-		values.second = GetIfcPropertyValue(property.boundedValue.upperBoundValue);
+		nlohmann::json values;
+		values["lower"] = GetIfcPropertyValue(property.boundedValue.lowerBoundValue);
+		values["upper"] = GetIfcPropertyValue(property.boundedValue.upperBoundValue);
 
 		return values;
 	}


### PR DESCRIPTION
## Problem

Since the DuckDB **artifact bundle** became the sole send payload, array-valued properties are silently dropped — a fidelity regression flagged in review (confirmed by testing: a Multiple-Choice property with 3 values never reaches the server).

`BundleWriter::WalkProperties` is a 1:1 port of the SDK's `EavExtraction`, which was shaped around **Revit** — where every parameter is a single scalar (`StorageType` is `Double`/`Integer`/`String`/`ElementId`, never a list). The SDK's `if (val is JArray) continue;` was therefore harmless. **Archicad is the first source that emits genuinely multi-valued properties**, so the verbatim port loses data with no conversion warning.

The other two items from the review (`{name,value}` with a non-scalar `value`, and nesting > 10 deep) don't fire for Archicad in practice: every `{name,value}` dict we build wraps a scalar, and the deepest property tree is ~4 levels.

## Affected shapes (all previously dropped)

Audited every contributor to `obj.properties` (`GetElementProperties`):

- **Native** (`GetElementBasicProperties`, user-defined **and** built-in): `API_PropertyListCollectionType`, `API_PropertyMultipleChoiceEnumerationCollectionType`
- **IFC** (`GetElementIfcProperties`, AC29 + legacy branches): `PropertyListValue`, `PropertyEnumeratedValue`, `PropertyBoundedValue` (serialized as a `[lower, upper]` array)

## Fix

- **`WalkProperties`** now handles `val.is_array()` by joining the array's scalar elements into a single **comma-separated** EAV row (reusing the same `String(value)` text as scalar rows). One place covers the native enums/lists and the IFC list/enumerated cases.
- **IFC Bounded values** are a lower/upper *range*, not a list, so they're reshaped **at the source** into a `{ "lower", "upper" }` object (both AC29 and legacy branches). The walk then recurses it into two keyed scalar rows — `properties.<pset>.<name>.lower` / `.upper` — instead of an array. (This has to be done upstream: once it's an array, the walk can't tell a bound-pair from a list.)

## Why not per-converter changes

Every array funnels through the single `WalkProperties` choke point, so one `is_array` branch catches all five shapes regardless of source. Only the bounded-range split needs a source-side touch, because it needs keyed output an array can't carry.

## Testing

- `SpeckleAddOn.vcxproj` builds clean (Debug, x64, AC29 / v143) → `Speckle.apx`.
- Note: this is a divergence from the SDK's verbatim EAV walk — an intentional, documented one, justified by Archicad's property model differing from Revit's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)