### PR TITLE
Native in-connector Speckle account sign-in (no Desktop Service)

### DIFF
--- a/AddOns/Speckle/CMakeLists.txt
+++ b/AddOns/Speckle/CMakeLists.txt
@@ -189,6 +189,10 @@ set (DiagnosticsFolder Sources/AddOn/Diagnostics)
 file (GLOB DiagnosticsFiles ${DiagnosticsFolder}/*.h ${DiagnosticsFolder}/*.cpp)
 source_group ("Diagnostics" FILES ${DiagnosticsFiles})
 
+set (AuthFolder Sources/AddOn/Auth)
+file (GLOB AuthFiles ${AuthFolder}/*.h ${AuthFolder}/*.cpp)
+source_group ("Auth" FILES ${AuthFiles})
+
 if (WIN32)
 	add_library (${SPECKLE_ADDON_LIB} SHARED
 		${AddOnFiles}
@@ -203,7 +207,8 @@ if (WIN32)
 		${UtilsFiles}
 		${ArtifactsFiles}
 		${NetworkFiles}
-		${DiagnosticsFiles})
+		${DiagnosticsFiles}
+		${AuthFiles})
 else ()
 	add_library (${SPECKLE_ADDON_LIB} MODULE
 		${AddOnFiles}
@@ -218,7 +223,8 @@ else ()
 		${UtilsFiles}
 		${ArtifactsFiles}
 		${NetworkFiles}
-		${DiagnosticsFiles})
+		${DiagnosticsFiles}
+		${AuthFiles})
 endif ()
 
 set_target_properties (${SPECKLE_ADDON_LIB} PROPERTIES OUTPUT_NAME ${SPECKLE_ADDON_NAME})
@@ -249,6 +255,7 @@ target_include_directories (${SPECKLE_ADDON_LIB} PUBLIC
 		${ArtifactsFolder}
 		${NetworkFolder}
 		${DiagnosticsFolder}
+		${AuthFolder}
 		${AC_API_DEVKIT_DIR}/Support/Inc
 		${LIB_INCLUDE_DIRS}
 )

--- a/AddOns/Speckle/Sources/AddOn/Auth/AccountFactory.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Auth/AccountFactory.cpp
@@ -1,0 +1,83 @@
+#include "AccountFactory.h"
+#include "CryptoUtils.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+    std::string TrimTrailingSlash(const std::string& url)
+    {
+        std::size_t end = url.size();
+        while (end > 0 && url[end - 1] == '/')
+            --end;
+        return url.substr(0, end);
+    }
+
+    // ASCII lower-case, matching string.ToLowerInvariant() for the ASCII inputs
+    // (email + url) the account id is computed from.
+    std::string AsciiToLower(const std::string& in)
+    {
+        std::string out = in;
+        for (char& c : out)
+        {
+            if (c >= 'A' && c <= 'Z')
+                c = static_cast<char>(c - 'A' + 'a');
+        }
+        return out;
+    }
+}
+
+AccountFactory::AccountFactory(std::shared_ptr<IHttpClient> http)
+    : _http(std::move(http))
+{
+}
+
+nlohmann::json AccountFactory::CreateAccount(
+    const std::string& serverUrl,
+    const std::string& token,
+    const std::string& refreshToken,
+    bool isFirstAccount)
+{
+    const std::string base = TrimTrailingSlash(serverUrl);
+
+    // Single bootstrap query: the fields Speckle persists to Accounts.db.
+    const char* query =
+        "query { activeUser { id name email company avatar } "
+        "serverInfo { name company description version migration { movedFrom movedTo } } }";
+
+    nlohmann::json requestBody;
+    requestBody["query"] = query;
+
+    HttpResponse response = _http->PostJson(base + "/graphql", requestBody.dump(), token);
+    if (!response.IsSuccess())
+        throw std::runtime_error("Failed to fetch account info (HTTP " + std::to_string(response.statusCode) + ").");
+
+    nlohmann::json parsed = nlohmann::json::parse(response.body);
+    if (!parsed.contains("data") || parsed["data"].is_null())
+        throw std::runtime_error("Unexpected response while fetching account info.");
+
+    nlohmann::json data = parsed["data"];
+    nlohmann::json activeUser = data.value("activeUser", nlohmann::json());
+    if (activeUser.is_null())
+        throw std::runtime_error("The server rejected the token (no active user).");
+
+    nlohmann::json serverInfo = data.value("serverInfo", nlohmann::json::object());
+    // These two are populated client-side (not returned by the GQL query),
+    // matching Speckle.Sdk's AccountManager.
+    serverInfo["url"] = base;
+    serverInfo["frontend2"] = true;
+
+    const std::string email = activeUser.value("email", std::string());
+    const std::string id = CryptoUtils::Md5UpperHex(AsciiToLower(email + base));
+
+    nlohmann::json account;
+    account["id"] = id;
+    account["token"] = token;
+    account["refreshToken"] = refreshToken;
+    account["isDefault"] = isFirstAccount;
+    account["isOnline"] = true;
+    account["serverInfo"] = serverInfo;
+    account["userInfo"] = activeUser;
+    return account;
+}

--- a/AddOns/Speckle/Sources/AddOn/Auth/AccountFactory.h
+++ b/AddOns/Speckle/Sources/AddOn/Auth/AccountFactory.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "IHttpClient.h"
+#include "json.hpp"
+
+// Builds a Speckle Account (as JSON) from freshly minted tokens, mirroring
+// Speckle.Sdk's AccountFactory: it runs one GraphQL query for the active user
+// and server info, then assembles the exact JSON shape stored in Accounts.db,
+// including the deterministic account id (MD5 of email+url) so accounts written
+// here dedup with those written by Speckle Manager / other connectors.
+class AccountFactory
+{
+public:
+    explicit AccountFactory(std::shared_ptr<IHttpClient> http);
+
+    // isFirstAccount seeds the "isDefault" flag (first account added is default).
+    // Throws std::runtime_error if the token is rejected (no active user).
+    nlohmann::json CreateAccount(
+        const std::string& serverUrl,
+        const std::string& token,
+        const std::string& refreshToken,
+        bool isFirstAccount);
+
+private:
+    std::shared_ptr<IHttpClient> _http;
+};

--- a/AddOns/Speckle/Sources/AddOn/Auth/CryptoUtils.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Auth/CryptoUtils.cpp
@@ -1,0 +1,132 @@
+#include "CryptoUtils.h"
+
+#include <stdexcept>
+#include <windows.h>
+#include <bcrypt.h>
+
+#include "picosha2.h"
+
+#pragma comment(lib, "bcrypt.lib")
+
+#ifndef STATUS_SUCCESS
+#define STATUS_SUCCESS ((NTSTATUS)0x00000000L)
+#endif
+
+namespace
+{
+    const char kBase64Alphabet[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+}
+
+namespace CryptoUtils
+{
+    std::vector<std::uint8_t> RandomBytes(std::size_t count)
+    {
+        std::vector<std::uint8_t> buffer(count);
+        NTSTATUS status = BCryptGenRandom(
+            nullptr,
+            buffer.data(),
+            static_cast<ULONG>(buffer.size()),
+            BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+        if (status != STATUS_SUCCESS)
+            throw std::runtime_error("BCryptGenRandom failed");
+        return buffer;
+    }
+
+    std::string Base64UrlEncode(const std::vector<std::uint8_t>& data)
+    {
+        std::string out;
+        out.reserve(((data.size() + 2) / 3) * 4);
+
+        std::size_t i = 0;
+        while (i + 3 <= data.size())
+        {
+            std::uint32_t n = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+            out.push_back(kBase64Alphabet[(n >> 18) & 0x3F]);
+            out.push_back(kBase64Alphabet[(n >> 12) & 0x3F]);
+            out.push_back(kBase64Alphabet[(n >> 6) & 0x3F]);
+            out.push_back(kBase64Alphabet[n & 0x3F]);
+            i += 3;
+        }
+
+        std::size_t remaining = data.size() - i;
+        if (remaining == 1)
+        {
+            std::uint32_t n = (data[i] << 16);
+            out.push_back(kBase64Alphabet[(n >> 18) & 0x3F]);
+            out.push_back(kBase64Alphabet[(n >> 12) & 0x3F]);
+        }
+        else if (remaining == 2)
+        {
+            std::uint32_t n = (data[i] << 16) | (data[i + 1] << 8);
+            out.push_back(kBase64Alphabet[(n >> 18) & 0x3F]);
+            out.push_back(kBase64Alphabet[(n >> 12) & 0x3F]);
+            out.push_back(kBase64Alphabet[(n >> 6) & 0x3F]);
+        }
+
+        // Make url-safe: standard base64 -> base64url, padding already omitted.
+        for (char& c : out)
+        {
+            if (c == '+') c = '-';
+            else if (c == '/') c = '_';
+        }
+        return out;
+    }
+
+    std::string GenerateCodeVerifier()
+    {
+        return Base64UrlEncode(RandomBytes(32));
+    }
+
+    std::string ComputeCodeChallenge(const std::string& codeVerifier)
+    {
+        std::vector<std::uint8_t> digest(picosha2::k_digest_size);
+        picosha2::hash256(codeVerifier.begin(), codeVerifier.end(), digest.begin(), digest.end());
+        return Base64UrlEncode(digest);
+    }
+
+    std::string Md5UpperHex(const std::string& asciiInput)
+    {
+        BCRYPT_ALG_HANDLE hAlg = nullptr;
+        BCRYPT_HASH_HANDLE hHash = nullptr;
+
+        try
+        {
+            if (BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_MD5_ALGORITHM, nullptr, 0) != STATUS_SUCCESS)
+                throw std::runtime_error("BCryptOpenAlgorithmProvider(MD5) failed");
+
+            if (BCryptCreateHash(hAlg, &hHash, nullptr, 0, nullptr, 0, 0) != STATUS_SUCCESS)
+                throw std::runtime_error("BCryptCreateHash failed");
+
+            if (BCryptHashData(
+                    hHash,
+                    reinterpret_cast<PUCHAR>(const_cast<char*>(asciiInput.data())),
+                    static_cast<ULONG>(asciiInput.size()),
+                    0) != STATUS_SUCCESS)
+                throw std::runtime_error("BCryptHashData failed");
+
+            std::uint8_t digest[16];
+            if (BCryptFinishHash(hHash, digest, sizeof(digest), 0) != STATUS_SUCCESS)
+                throw std::runtime_error("BCryptFinishHash failed");
+
+            static const char* kHex = "0123456789ABCDEF";
+            std::string out;
+            out.reserve(32);
+            for (std::uint8_t b : digest)
+            {
+                out.push_back(kHex[b >> 4]);
+                out.push_back(kHex[b & 0x0F]);
+            }
+
+            BCryptDestroyHash(hHash);
+            BCryptCloseAlgorithmProvider(hAlg, 0);
+            return out;
+        }
+        catch (...)
+        {
+            if (hHash) BCryptDestroyHash(hHash);
+            if (hAlg) BCryptCloseAlgorithmProvider(hAlg, 0);
+            throw;
+        }
+    }
+}

--- a/AddOns/Speckle/Sources/AddOn/Auth/CryptoUtils.h
+++ b/AddOns/Speckle/Sources/AddOn/Auth/CryptoUtils.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+// Small crypto helpers for the native OAuth (PKCE) account flow.
+// Windows-only: random bytes and MD5 come from CNG (bcrypt); SHA-256 reuses
+// the vendored picosha2. Mirrors Speckle.Sdk's AuthFlow / Crypt helpers.
+namespace CryptoUtils
+{
+    // Cryptographically strong random bytes (BCryptGenRandom).
+    std::vector<std::uint8_t> RandomBytes(std::size_t count);
+
+    // Base64url (RFC 4648 §5): '+'->'-', '/'->'_', padding '=' stripped.
+    std::string Base64UrlEncode(const std::vector<std::uint8_t>& data);
+
+    // PKCE code_verifier: base64url of 32 random bytes.
+    std::string GenerateCodeVerifier();
+
+    // PKCE code_challenge: base64url(SHA-256(verifier)) — the S256 method.
+    std::string ComputeCodeChallenge(const std::string& codeVerifier);
+
+    // MD5 of the ASCII bytes of input, formatted as 32 UPPERCASE hex chars.
+    // Matches Speckle.Sdk Crypt.Md5(input, "X2"). NOTE: caller must pass the
+    // already-lower-cased string (the SDK lower-cases before hashing).
+    std::string Md5UpperHex(const std::string& asciiInput);
+}

--- a/AddOns/Speckle/Sources/AddOn/Auth/LoopbackListener.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Auth/LoopbackListener.cpp
@@ -1,0 +1,210 @@
+#include "LoopbackListener.h"
+#include "UserCancelledException.h"
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#pragma comment(lib, "ws2_32.lib")
+
+namespace
+{
+    // RAII for WSAStartup/WSACleanup. WinHTTP does its own networking, so the
+    // OAuth listener owns the only Winsock usage in the add-on.
+    struct WinsockScope
+    {
+        bool ok = false;
+        WinsockScope()
+        {
+            WSADATA data;
+            ok = (WSAStartup(MAKEWORD(2, 2), &data) == 0);
+        }
+        ~WinsockScope()
+        {
+            if (ok)
+                WSACleanup();
+        }
+    };
+
+    // The page the user sees in their browser once the redirect lands.
+    const char* kSuccessBody =
+        "<!doctype html><html><head><meta charset=\"utf-8\"><title>Speckle</title></head>"
+        "<body style=\"font-family:sans-serif;text-align:center;padding-top:80px\">"
+        "<h2>Authentication complete</h2>"
+        "<p>You can close this window and return to Archicad.</p></body></html>";
+
+    std::string PercentDecode(const std::string& in)
+    {
+        std::string out;
+        out.reserve(in.size());
+        for (std::size_t i = 0; i < in.size(); ++i)
+        {
+            if (in[i] == '%' && i + 2 < in.size())
+            {
+                auto hexVal = [](char c) -> int {
+                    if (c >= '0' && c <= '9') return c - '0';
+                    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+                    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+                    return -1;
+                };
+                int hi = hexVal(in[i + 1]);
+                int lo = hexVal(in[i + 2]);
+                if (hi >= 0 && lo >= 0)
+                {
+                    out.push_back(static_cast<char>((hi << 4) | lo));
+                    i += 2;
+                    continue;
+                }
+            }
+            if (in[i] == '+')
+                out.push_back(' ');
+            else
+                out.push_back(in[i]);
+        }
+        return out;
+    }
+
+    // Pulls a query parameter value out of a raw HTTP request line
+    // ("GET /?access_code=abc&foo=bar HTTP/1.1").
+    bool TryGetQueryParam(const std::string& requestLine, const std::string& key, std::string& value)
+    {
+        std::string needle = key + "=";
+        std::size_t queryStart = requestLine.find('?');
+        if (queryStart == std::string::npos)
+            return false;
+
+        std::size_t pos = requestLine.find(needle, queryStart);
+        while (pos != std::string::npos)
+        {
+            // Ensure the match starts right after '?' or '&' (not mid-token).
+            char prev = requestLine[pos - 1];
+            if (prev == '?' || prev == '&')
+            {
+                std::size_t valStart = pos + needle.size();
+                std::size_t valEnd = requestLine.find_first_of("& \t", valStart);
+                if (valEnd == std::string::npos)
+                    valEnd = requestLine.size();
+                value = PercentDecode(requestLine.substr(valStart, valEnd - valStart));
+                return true;
+            }
+            pos = requestLine.find(needle, pos + needle.size());
+        }
+        return false;
+    }
+
+    void SendHttpResponse(SOCKET client, const std::string& body)
+    {
+        std::string response =
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: text/html; charset=utf-8\r\n"
+            "Content-Length: " + std::to_string(body.size()) + "\r\n"
+            "Connection: close\r\n"
+            "\r\n" + body;
+        send(client, response.c_str(), static_cast<int>(response.size()), 0);
+    }
+}
+
+LoopbackListener::LoopbackListener(unsigned short port)
+    : _listenSocket(INVALID_SOCKET)
+{
+    static WinsockScope winsock; // one-time init for the process lifetime
+    if (!winsock.ok)
+        throw std::runtime_error("WSAStartup failed");
+
+    SOCKET listenSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (listenSocket == INVALID_SOCKET)
+        throw std::runtime_error("Failed to create listener socket");
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+
+    if (bind(listenSocket, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == SOCKET_ERROR)
+    {
+        closesocket(listenSocket);
+        throw std::runtime_error(
+            "Failed to bind 127.0.0.1:" + std::to_string(port) +
+            " for the sign-in redirect (another sign-in may be in progress).");
+    }
+
+    if (listen(listenSocket, 1) == SOCKET_ERROR)
+    {
+        closesocket(listenSocket);
+        throw std::runtime_error("Failed to listen on the sign-in redirect socket");
+    }
+
+    _listenSocket = listenSocket;
+}
+
+LoopbackListener::~LoopbackListener()
+{
+    if (_listenSocket != INVALID_SOCKET)
+        closesocket(static_cast<SOCKET>(_listenSocket));
+}
+
+std::string LoopbackListener::WaitForAccessCode(int timeoutSeconds, const std::function<bool()>& isCanceled)
+{
+    SOCKET listenSocket = static_cast<SOCKET>(_listenSocket);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeoutSeconds);
+
+    for (;;)
+    {
+        if (isCanceled && isCanceled())
+            throw UserCancelledException("Sign-in cancelled");
+
+        if (std::chrono::steady_clock::now() >= deadline)
+            throw std::runtime_error("Timed out waiting for the browser sign-in to complete.");
+
+        // Poll the listening socket with a short timeout so we can re-check
+        // cancellation/deadline and keep the process window responsive.
+        fd_set readSet;
+        FD_ZERO(&readSet);
+        FD_SET(listenSocket, &readSet);
+        timeval tv{};
+        tv.tv_sec = 0;
+        tv.tv_usec = 200 * 1000; // 200ms
+
+        int ready = select(0, &readSet, nullptr, nullptr, &tv);
+        if (ready == SOCKET_ERROR)
+            throw std::runtime_error("select() failed on the sign-in redirect socket");
+        if (ready == 0)
+            continue; // nothing yet — loop and re-check cancel/deadline
+
+        SOCKET client = accept(listenSocket, nullptr, nullptr);
+        if (client == INVALID_SOCKET)
+            continue;
+
+        // Read the request (we only need the request line, which arrives first).
+        std::string request;
+        char buffer[2048];
+        int received = recv(client, buffer, sizeof(buffer), 0);
+        if (received > 0)
+            request.assign(buffer, static_cast<std::size_t>(received));
+
+        std::string firstLine = request.substr(0, request.find("\r\n"));
+
+        std::string denied;
+        if (TryGetQueryParam(firstLine, "denied", denied))
+        {
+            SendHttpResponse(client, kSuccessBody);
+            closesocket(client);
+            throw std::runtime_error("Sign-in was denied.");
+        }
+
+        std::string accessCode;
+        if (TryGetQueryParam(firstLine, "access_code", accessCode) && !accessCode.empty())
+        {
+            SendHttpResponse(client, kSuccessBody);
+            closesocket(client);
+            return accessCode;
+        }
+
+        // Unrelated request (e.g. a favicon probe) — answer politely and keep waiting.
+        SendHttpResponse(client, kSuccessBody);
+        closesocket(client);
+    }
+}

--- a/AddOns/Speckle/Sources/AddOn/Auth/LoopbackListener.h
+++ b/AddOns/Speckle/Sources/AddOn/Auth/LoopbackListener.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <functional>
+#include <string>
+
+// Minimal single-shot HTTP loopback listener used to catch the OAuth redirect
+// (http://localhost:29355/?access_code=...). Mirrors the HttpListener that
+// Speckle.Sdk's AuthFlow spins up. Windows/Winsock only.
+class LoopbackListener
+{
+public:
+    // Binds 127.0.0.1:<port> and starts listening immediately (throws on failure,
+    // e.g. the port is already taken by another in-flight sign-in).
+    explicit LoopbackListener(unsigned short port);
+    ~LoopbackListener();
+
+    LoopbackListener(const LoopbackListener&) = delete;
+    LoopbackListener& operator=(const LoopbackListener&) = delete;
+
+    // Blocks until the browser hits the redirect URL, then returns the value of
+    // the "access_code" query parameter. Writes a small HTML page back to the
+    // browser before returning.
+    //
+    // isCanceled is polled (~5x/sec) so the caller can abort via the Archicad
+    // process window; when it returns true a UserCancelledException is thrown.
+    // Throws std::runtime_error on timeout, on a "?denied=true" redirect, or on
+    // a socket error.
+    std::string WaitForAccessCode(int timeoutSeconds, const std::function<bool()>& isCanceled);
+
+private:
+    unsigned long long _listenSocket; // SOCKET (kept opaque to avoid winsock.h in the header)
+};

--- a/AddOns/Speckle/Sources/AddOn/Auth/OAuthFlow.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Auth/OAuthFlow.cpp
@@ -1,0 +1,114 @@
+#include "OAuthFlow.h"
+#include "CryptoUtils.h"
+#include "LoopbackListener.h"
+
+#include <stdexcept>
+#include <windows.h>
+#include <shellapi.h>
+
+#include "json.hpp"
+
+#pragma comment(lib, "shell32.lib")
+
+namespace
+{
+    // Public-client identity + loopback redirect, matching AuthApp.ConnectorsV3.
+    const char* kAppId = "connectrV3";
+    const char* kAppSecret = "connectrV3";
+    const unsigned short kRedirectPort = 29355;
+
+    std::string TrimTrailingSlash(const std::string& url)
+    {
+        std::size_t end = url.size();
+        while (end > 0 && url[end - 1] == '/')
+            --end;
+        return url.substr(0, end);
+    }
+
+    void OpenInBrowser(const std::string& url)
+    {
+        int wideLen = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
+        std::wstring wideUrl(wideLen > 0 ? wideLen - 1 : 0, L'\0');
+        if (wideLen > 0)
+            MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, &wideUrl[0], wideLen);
+
+        HINSTANCE result = ShellExecuteW(nullptr, L"open", wideUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+        // ShellExecute returns a value <= 32 on failure.
+        if (reinterpret_cast<INT_PTR>(result) <= 32)
+            throw std::runtime_error("Failed to open the system browser for sign-in.");
+    }
+}
+
+OAuthFlow::OAuthFlow(std::shared_ptr<IHttpClient> http)
+    : _http(std::move(http))
+{
+}
+
+OAuthTokens OAuthFlow::Authenticate(
+    const std::string& serverUrl,
+    int timeoutSeconds,
+    const std::function<bool()>& isCanceled)
+{
+    const std::string base = TrimTrailingSlash(serverUrl);
+
+    // 1. Probe for the modern PKCE endpoint; fall back to the legacy one.
+    bool useNewEndpoint = false;
+    try
+    {
+        HttpResponse probe = _http->Get(base + "/oauth/token", "");
+        useNewEndpoint = (probe.statusCode == 200);
+    }
+    catch (...)
+    {
+        useNewEndpoint = false;
+    }
+
+    // 2. PKCE code_verifier (and, for the new flow, its S256 challenge).
+    const std::string codeVerifier = CryptoUtils::GenerateCodeVerifier();
+
+    std::string authUrl;
+    std::string tokenEndpoint;
+    if (useNewEndpoint)
+    {
+        const std::string challenge = CryptoUtils::ComputeCodeChallenge(codeVerifier);
+        authUrl = base + "/authn/verify/" + kAppId + "/" + challenge + "?code_challenge_method=S256";
+        tokenEndpoint = base + "/oauth/token";
+    }
+    else
+    {
+        authUrl = base + "/authn/verify/" + std::string(kAppId) + "/" + codeVerifier;
+        tokenEndpoint = base + "/auth/token";
+    }
+
+    // 3. Start the redirect listener *before* opening the browser so we never
+    //    miss a fast redirect.
+    LoopbackListener listener(kRedirectPort);
+
+    // 4. Hand off to the system browser and wait for the redirect.
+    OpenInBrowser(authUrl);
+    const std::string accessCode = listener.WaitForAccessCode(timeoutSeconds, isCanceled);
+
+    // 5. Exchange the access code for tokens.
+    nlohmann::json body;
+    body["appId"] = kAppId;
+    body["accessCode"] = accessCode;
+    if (useNewEndpoint)
+    {
+        body["codeVerifier"] = codeVerifier;
+    }
+    else
+    {
+        body["appSecret"] = kAppSecret;
+        body["challenge"] = codeVerifier;
+    }
+
+    HttpResponse response = _http->PostJson(tokenEndpoint, body.dump(), "");
+    if (!response.IsSuccess())
+        throw std::runtime_error("Token exchange failed (HTTP " + std::to_string(response.statusCode) + ").");
+
+    nlohmann::json parsed = nlohmann::json::parse(response.body);
+    OAuthTokens tokens;
+    tokens.token = parsed.at("token").get<std::string>();
+    tokens.refreshToken = parsed.value("refreshToken", std::string());
+    return tokens;
+}

--- a/AddOns/Speckle/Sources/AddOn/Auth/OAuthFlow.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Auth/OAuthFlow.cpp
@@ -1,14 +1,11 @@
 #include "OAuthFlow.h"
 #include "CryptoUtils.h"
 #include "LoopbackListener.h"
+#include "UrlLauncher.h"
 
 #include <stdexcept>
-#include <windows.h>
-#include <shellapi.h>
 
 #include "json.hpp"
-
-#pragma comment(lib, "shell32.lib")
 
 namespace
 {
@@ -23,19 +20,6 @@ namespace
         while (end > 0 && url[end - 1] == '/')
             --end;
         return url.substr(0, end);
-    }
-
-    void OpenInBrowser(const std::string& url)
-    {
-        int wideLen = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
-        std::wstring wideUrl(wideLen > 0 ? wideLen - 1 : 0, L'\0');
-        if (wideLen > 0)
-            MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, &wideUrl[0], wideLen);
-
-        HINSTANCE result = ShellExecuteW(nullptr, L"open", wideUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
-        // ShellExecute returns a value <= 32 on failure.
-        if (reinterpret_cast<INT_PTR>(result) <= 32)
-            throw std::runtime_error("Failed to open the system browser for sign-in.");
     }
 }
 
@@ -85,7 +69,7 @@ OAuthTokens OAuthFlow::Authenticate(
     LoopbackListener listener(kRedirectPort);
 
     // 4. Hand off to the system browser and wait for the redirect.
-    OpenInBrowser(authUrl);
+    UrlLauncher::Open(authUrl);
     const std::string accessCode = listener.WaitForAccessCode(timeoutSeconds, isCanceled);
 
     // 5. Exchange the access code for tokens.

--- a/AddOns/Speckle/Sources/AddOn/Auth/OAuthFlow.h
+++ b/AddOns/Speckle/Sources/AddOn/Auth/OAuthFlow.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "IHttpClient.h"
+
+struct OAuthTokens
+{
+    std::string token;
+    std::string refreshToken;
+};
+
+// Native port of Speckle.Sdk's AuthFlow: a browser-based PKCE authorization-code
+// flow. Probes for the new /oauth/token endpoint (falling back to the legacy
+// /auth/token), opens the system browser at the server's authn page, catches the
+// redirect on a loopback listener, and exchanges the access code for tokens.
+// Talks to the server exclusively through IHttpClient (WinHTTP).
+class OAuthFlow
+{
+public:
+    explicit OAuthFlow(std::shared_ptr<IHttpClient> http);
+
+    // Runs the whole flow synchronously. isCanceled is polled while waiting for
+    // the browser redirect so the caller can abort (throws UserCancelledException).
+    OAuthTokens Authenticate(
+        const std::string& serverUrl,
+        int timeoutSeconds,
+        const std::function<bool()>& isCanceled);
+
+private:
+    std::shared_ptr<IHttpClient> _http;
+};

--- a/AddOns/Speckle/Sources/AddOn/Connector/AccountDatabase.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/AccountDatabase.cpp
@@ -87,7 +87,7 @@ void AccountDatabase::LoadAccountsFromDB()
     sqlite3_stmt* stmt;
     int rc;
 
-    // Open the database (or create it if it doesn’t exist)
+    // Open the database (or create it if it doesnï¿½t exist)
     rc = sqlite3_open(GetAccountsDatabasePath(), &db);
     if (rc != SQLITE_OK)
     {
@@ -166,6 +166,61 @@ void AccountDatabase::RemoveAccountById(const std::string& id)
     }
 
     // Finalize and close
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+}
+
+void AccountDatabase::SaveAccount(const std::string& id, const nlohmann::json& account)
+{
+    sqlite3* db;
+    int rc = sqlite3_open(GetAccountsDatabasePath(), &db);
+    if (rc != SQLITE_OK)
+    {
+        std::cerr << "Error opening database: " << sqlite3_errmsg(db) << std::endl;
+        sqlite3_close(db);
+        throw std::runtime_error("Failed to open the Speckle accounts database.");
+    }
+
+    // The DB may not exist yet on a machine that never ran Speckle Manager.
+    // Create the table with the same schema the Speckle SDK uses so the store
+    // stays compatible with the Manager and other connectors.
+    const char* createSql =
+        "CREATE TABLE IF NOT EXISTS objects (hash TEXT PRIMARY KEY, content TEXT) WITHOUT ROWID;";
+    char* errMsg = nullptr;
+    rc = sqlite3_exec(db, createSql, nullptr, nullptr, &errMsg);
+    if (rc != SQLITE_OK)
+    {
+        std::string msg = errMsg ? errMsg : "unknown error";
+        sqlite3_free(errMsg);
+        sqlite3_close(db);
+        throw std::runtime_error("Failed to prepare the accounts table: " + msg);
+    }
+
+    const char* sql = "INSERT OR REPLACE INTO objects (hash, content) VALUES (?, ?);";
+    sqlite3_stmt* stmt;
+    rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
+    if (rc != SQLITE_OK)
+    {
+        std::cerr << "Error preparing statement: " << sqlite3_errmsg(db) << std::endl;
+        sqlite3_close(db);
+        throw std::runtime_error("Failed to prepare the account insert statement.");
+    }
+
+    std::string content = account.dump();
+    sqlite3_bind_text(stmt, 1, id.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 2, content.c_str(), -1, SQLITE_TRANSIENT);
+
+    rc = sqlite3_step(stmt);
+    if (rc != SQLITE_DONE)
+    {
+        std::cerr << "Error executing statement: " << sqlite3_errmsg(db) << std::endl;
+        sqlite3_finalize(stmt);
+        sqlite3_close(db);
+        throw std::runtime_error("Failed to write the account to the database.");
+    }
+
+    _accountsData[id] = account;
+
     sqlite3_finalize(stmt);
     sqlite3_close(db);
 }

--- a/AddOns/Speckle/Sources/AddOn/Connector/AccountDatabase.h
+++ b/AddOns/Speckle/Sources/AddOn/Connector/AccountDatabase.h
@@ -13,6 +13,7 @@ public:
     std::string GetTokenByAccountId(const std::string& id) const override;
     void RefreshFromDB() override;
     void RemoveAccountById(const std::string& id) override;
+    void SaveAccount(const std::string& id, const nlohmann::json& account) override;
 
 private:
     std::map<std::string, nlohmann::json> _accountsData;

--- a/AddOns/Speckle/Sources/AddOn/Connector/Bridges/AccountBridge.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/Bridges/AccountBridge.cpp
@@ -2,13 +2,20 @@
 #include "Connector.h"
 #include "InvalidMethodNameException.h"
 #include "ArchiCadApiException.h"
+#include "UserCancelledException.h"
+#include "WinHttpClient.h"
+#include "OAuthFlow.h"
+#include "AccountFactory.h"
+#include "ToastNotification.h"
+
+#include <memory>
 
 
 AccountBridge::AccountBridge(IBrowserAdapter* browser)
 {
 	accountsBinding = std::make_unique<Binding>(
 		"accountsBinding",
-		std::vector<std::string>{ "GetAccounts", "removeAccount" },
+		std::vector<std::string>{ "GetAccounts", "removeAccount", "AddAccount", "AuthenticateAccount" },
 		browser,
         this
     );
@@ -23,6 +30,14 @@ void AccountBridge::RunMethod(const RunMethodEventArgs& args)
     else if (args.methodName == "removeAccount")
     {
         RemoveAccount(args);
+    }
+    else if (args.methodName == "AddAccount")
+    {
+        AddAccount(args);
+    }
+    else if (args.methodName == "AuthenticateAccount")
+    {
+        AuthenticateAccount(args);
     }
 	else
 	{
@@ -46,4 +61,70 @@ void AccountBridge::RemoveAccount(const RunMethodEventArgs& args)
     CONNECTOR.GetAccountDatabase().RemoveAccountById(accountId);
 
     args.eventSource->ResponseReady(args.methodId);
+}
+
+void AccountBridge::AddAccount(const RunMethodEventArgs& args)
+{
+    // Called by the frontend's "Log in with OAuth token" flow, which builds the
+    // account itself (incl. its id) and hands it to us to persist. Mirrors the
+    // .NET AccountBinding.AddAccount(accountId, account).
+    if (args.data.size() < 2)
+        throw std::invalid_argument("Too few arguments when calling " + args.methodName);
+
+    std::string accountId = args.data[0].get<std::string>();
+    CONNECTOR.GetAccountDatabase().SaveAccount(accountId, args.data[1]);
+
+    args.eventSource->ResponseReady(args.methodId);
+}
+
+void AccountBridge::AuthenticateAccount(const RunMethodEventArgs& args)
+{
+    if (args.data.size() < 1)
+        throw std::invalid_argument("Too few arguments when calling " + args.methodName);
+
+    std::string serverUrl = args.data[0].get<std::string>();
+
+    // Long-running: run synchronously behind a process window (mirrors the Send
+    // flow) so the user can cancel while the browser sign-in is in progress.
+    CONNECTOR.GetProcessWindow().Init("Signing in to Speckle", 1);
+    CONNECTOR.GetProcessWindow().SetNextProcessPhase("Waiting for browser sign-in", 1);
+
+    try
+    {
+        auto http = std::make_shared<WinHttpClient>();
+
+        OAuthFlow flow(http);
+        OAuthTokens tokens = flow.Authenticate(
+            serverUrl,
+            // The DUI3 bridge rejects the call after 60s (GenericBridge.TIMEOUT_MS),
+            // so waiting longer is pointless; time out just under that and let the
+            // frontend surface its "try OAuth token" fallback.
+            55,
+            [] { return CONNECTOR.GetProcessWindow().IsProcessCanceled(); });
+
+        CONNECTOR.GetAccountDatabase().RefreshFromDB();
+        bool isFirstAccount = CONNECTOR.GetAccountDatabase().GetAccounts().empty();
+
+        AccountFactory factory(http);
+        nlohmann::json account = factory.CreateAccount(serverUrl, tokens.token, tokens.refreshToken, isFirstAccount);
+
+        CONNECTOR.GetAccountDatabase().SaveAccount(account["id"].get<std::string>(), account);
+
+        CONNECTOR.GetProcessWindow().Close();
+        args.eventSource->SetResult(args.methodId, account);
+    }
+    catch (const UserCancelledException&)
+    {
+        CONNECTOR.GetProcessWindow().Close();
+        // Resolve the pending JS promise with an empty object (not null) so the
+        // frontend's `acc.token` check is falsy rather than throwing.
+        args.eventSource->SetResult(args.methodId, nlohmann::json::object());
+    }
+    catch (const std::exception& ex)
+    {
+        CONNECTOR.GetProcessWindow().Close();
+        args.eventSource->SetToastNotification(
+            ToastNotification{ ToastNotificationType::TOAST_DANGER, "Could not add account", ex.what(), false });
+        args.eventSource->SetResult(args.methodId, nlohmann::json::object());
+    }
 }

--- a/AddOns/Speckle/Sources/AddOn/Connector/Bridges/AccountBridge.h
+++ b/AddOns/Speckle/Sources/AddOn/Connector/Bridges/AccountBridge.h
@@ -16,4 +16,6 @@ private:
 
     void GetAccounts(const RunMethodEventArgs& args);
     void RemoveAccount(const RunMethodEventArgs& args);
+    void AddAccount(const RunMethodEventArgs& args);
+    void AuthenticateAccount(const RunMethodEventArgs& args);
 };

--- a/AddOns/Speckle/Sources/AddOn/Connector/Bridges/BaseBridge.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/Bridges/BaseBridge.cpp
@@ -2,6 +2,7 @@
 #include "Connector.h"
 #include "InvalidMethodNameException.h"
 #include "ArchiCadApiException.h"
+#include "UrlLauncher.h"
 
 
 BaseBridge::BaseBridge(IBrowserAdapter* browser)
@@ -166,11 +167,10 @@ void BaseBridge::OpenUrl(const RunMethodEventArgs& args)
         throw std::invalid_argument("Too few of arguments when calling " + args.methodName);
 
     std::string url = args.data[0].get<std::string>();
-    std::string command = "start " + url;
-    system(command.c_str());
+    UrlLauncher::Open(url);
 }
 
-void BaseBridge::RemoveModel(const RunMethodEventArgs& args) 
+void BaseBridge::RemoveModel(const RunMethodEventArgs& args)
 {
     if (args.data.size() < 1)
         throw std::invalid_argument("Too few of arguments when calling " + args.methodName);

--- a/AddOns/Speckle/Sources/AddOn/Connector/Bridges/ConfigBridge.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/Bridges/ConfigBridge.cpp
@@ -4,6 +4,7 @@
 #include "Connector.h"
 #include "ConnectorConfig.h"
 #include "AccountsConfig.h"
+#include "UrlLauncher.h"
 #include "WorkspacesConfig.h"
 
 
@@ -115,8 +116,7 @@ void ConfigBridge::OpenUrl(const RunMethodEventArgs& args)
         throw std::invalid_argument("Too few of arguments when calling " + args.methodName);
 
     std::string url = args.data[0].get<std::string>();
-    std::string command = "start " + url;
-    system(command.c_str());
+    UrlLauncher::Open(url);
 }
 
 void ConfigBridge::GetUserSelectedAccountId(const RunMethodEventArgs& args)

--- a/AddOns/Speckle/Sources/AddOn/Connector/IAccountDatabase.h
+++ b/AddOns/Speckle/Sources/AddOn/Connector/IAccountDatabase.h
@@ -13,4 +13,8 @@ public:
     virtual std::string GetTokenByAccountId(const std::string& id) const = 0;
     virtual void RefreshFromDB() = 0;
     virtual void RemoveAccountById(const std::string& id) = 0;
+
+    // Upserts an account (INSERT OR REPLACE) into the shared Accounts.db under
+    // the given id (the account's computed hash) with the JSON payload.
+    virtual void SaveAccount(const std::string& id, const nlohmann::json& account) = 0;
 };

--- a/AddOns/Speckle/Sources/AddOn/Utils/UrlLauncher.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Utils/UrlLauncher.cpp
@@ -1,0 +1,24 @@
+#include "UrlLauncher.h"
+
+#include <stdexcept>
+#include <string>
+#include <windows.h>
+#include <shellapi.h>
+
+#pragma comment(lib, "shell32.lib")
+
+namespace UrlLauncher
+{
+    void Open(const std::string& url)
+    {
+        int wideLen = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
+        std::wstring wideUrl(wideLen > 0 ? wideLen - 1 : 0, L'\0');
+        if (wideLen > 0)
+            MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, &wideUrl[0], wideLen);
+
+        HINSTANCE result = ShellExecuteW(nullptr, L"open", wideUrl.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+        // ShellExecute returns a value <= 32 on failure.
+        if (reinterpret_cast<INT_PTR>(result) <= 32)
+            throw std::runtime_error("Failed to open URL in the default browser.");
+    }
+}

--- a/AddOns/Speckle/Sources/AddOn/Utils/UrlLauncher.h
+++ b/AddOns/Speckle/Sources/AddOn/Utils/UrlLauncher.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+// Opens URLs in the user's default browser. Uses ShellExecuteW rather than
+// system("start ...") so the full URL is preserved verbatim — cmd's `start`
+// treats '&' as a command separator, which silently truncates query strings
+// (e.g. OAuth ...?a=1&code_challenge_method=S256 loses the second param).
+namespace UrlLauncher
+{
+    // Throws std::runtime_error if the shell fails to open the URL.
+    void Open(const std::string& url);
+}


### PR DESCRIPTION
## What & why

Users currently can't add a Speckle account from the Archicad connector without installing the legacy **Speckle Desktop Service** — the DUI3 "Add account" screen falls back to a "Download Desktop Service" prompt because the connector didn't expose an in-process auth method.

This PR adds a **native PKCE OAuth account-add flow** (a C++ port of `Speckle.Sdk`'s `AuthFlow`), so signing in works directly from the connector. Accounts are written to the same shared `%APPDATA%\Speckle\Accounts.db` store, so they dedup with accounts created by Speckle Manager or other connectors.

## How it works

The DUI3 "**Log in**" button calls `authenticateAccount(serverUrl)`, which:
1. Probes `GET {server}/oauth/token` (falls back to the legacy `/auth/token` for older servers).
2. Generates a PKCE `code_verifier`/`code_challenge`.
3. Opens the **system browser** at the server's authorize page.
4. Catches the redirect on a **loopback listener** (`127.0.0.1:29355`).
5. Exchanges the access code for tokens, fetches `activeUser`+`serverInfo` via GraphQL, and persists the account.

## New `Auth/` module
- **CryptoUtils** — CSPRNG + MD5 via Windows CNG (bcrypt), SHA-256 via the vendored picosha2, base64url. `account.id = UPPERCASE hex MD5(ascii(lower(email+url)))`, validated against the SDK's own test vectors (the vendored `Libs/md5` is an incomplete stub, so CNG is used instead).
- **LoopbackListener** — Winsock listener catching the OAuth redirect, with timeout + process-window cancellation.
- **OAuthFlow** — the probe / PKCE / browser / listener / token-exchange orchestration.
- **AccountFactory** — GraphQL fetch + Account JSON assembly.

## Wiring
- `AccountBridge` now exposes **`AddAccount`** and **`AuthenticateAccount`**. The frontend gates the "Log in" button on the `AddAccount` capability; `AuthenticateAccount` runs the native flow synchronously behind a cancellable `IProcessWindow`, capped at **55s** (just under the DUI3 bridge's 60s call timeout).
- `AccountDatabase.SaveAccount` upserts into `Accounts.db` (creating the `objects` table if the file doesn't exist yet — e.g. a machine that never ran Manager).

## Testing
- Compiles clean on **AC29 (v143)** and **AC27 (v142)**.
- `account.id` MD5 validated against SDK test vectors; PKCE verifier/challenge confirmed valid base64url.
- **Live-tested:** the native "Log in" flow works end-to-end against a real server.

## Notes
- The frontend also shows a "Log in with OAuth token" button (a manual copy-paste fallback for environments that can't run a loopback listener). It shares the same `AddAccount` capability flag as the working "Log in" button, so it can't be hidden from the connector side. It's a secondary path and not required for normal desktop use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)