### PR TITLE
Preserve source material names in Big Truck bundles (ENG-8879)

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
@@ -490,7 +490,7 @@ static void AppendNodeRow(
     nodes.endRow();
 }
 
-int BundleWriter::AddMaterial(const std::string& materialKey, int argb, double opacity, double metalness, double roughness)
+int BundleWriter::AddMaterial(const std::string& materialKey, const std::string& name, int argb, double opacity, double metalness, double roughness)
 {
     bool isNew;
     const int k = InternNode("mat:" + materialKey, isNew);
@@ -498,7 +498,7 @@ int BundleWriter::AddMaterial(const std::string& materialKey, int argb, double o
     {
         AppendNodeRow(
             _tables->nodes, k, static_cast<int>(bundlespec::NodeKind::MATERIAL),
-            nullptr, nullptr, nullptr, nullptr, nullptr, &argb, &opacity, &metalness, &roughness, nullptr);
+            name.empty() ? nullptr : &name, nullptr, nullptr, nullptr, nullptr, &argb, &opacity, &metalness, &roughness, nullptr);
     }
     return k;
 }

--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
@@ -65,7 +65,7 @@ public:
         const std::string& typeName = "mesh");
 
     // ── node namespace (value entities) ───────────────────────────────
-    int AddMaterial(const std::string& materialKey, int argb, double opacity, double metalness, double roughness);
+    int AddMaterial(const std::string& materialKey, const std::string& name, int argb, double opacity, double metalness, double roughness);
     int AddLevel(const std::string& levelKey, const std::string& name, double elevation);
     int AddCollection(const std::string& collectionKey, const std::string& name, const int* parentK, const std::string& subtype);
     int AddContainer(const std::string& containerKey, const std::string& name, const int* parentK, const std::string& subtype);

--- a/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
@@ -31,7 +31,7 @@ namespace
         Material material = CONNECTOR.GetHostToSpeckleConverter().GetModelMaterial(materialIndex);
         const int argb = static_cast<int>(material.diffuse);
         const int k = writer.AddMaterial(
-            std::to_string(materialIndex), argb, material.opacity, material.metalness, material.roughness);
+            std::to_string(materialIndex), material.name, argb, material.opacity, material.metalness, material.roughness);
         cache.emplace(materialIndex, k);
         return k;
     }

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetModelMaterial.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetModelMaterial.cpp
@@ -17,7 +17,8 @@ Material HostToSpeckleConverter::GetModelMaterial(int materialIndex)
 	acModel.GetMaterial(attributeIndex, &modelerMaterial);
 
 	auto color = modelerMaterial.GetSurfaceColor();
-	auto name = modelerMaterial.GetName().ToCStr().Get();
+	// UTF-8 explicitly: bundle parquet strings are UTF-8, CC_Default is the system codepage
+	auto name = modelerMaterial.GetName().ToCStr(CC_UTF8).Get();
 
 	Material material;
 	material.name = name;


### PR DESCRIPTION
Fixes https://linear.app/speckle/issue/ENG-8879/archicad-preserve-material-names-in-big-truck-bundles

https://github.com/user-attachments/assets/3fdc031f-1d4f-46fc-b2fb-88632ec1e865

Send read the Archicad surface name via `GetModelMaterial` but never passed it to the bundle, so every MATERIAL node was written with `name = null` and receive fell back to `Speckle Material <K>`.

- `BundleWriter::AddMaterial` now takes the material name and writes it into the MATERIAL node row (null only when genuinely empty).
- `GetOrAddMaterialNode` passes `Material.name` through.
- `GetModelMaterial` converts the name with `ToCStr(CC_UTF8)` so Unicode names survive the parquet bundle.

No receiver change needed: receive already prefers the node name and sanitizes GDL-special characters (names are emitted inside CDATA, and `SanitizeName` strips `"` `<` `>` etc.).

