### PR TITLE
Emit model topology: layers, hosting, groups, curtain-wall hierarchy, zones

### DIFF
--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
@@ -588,6 +588,7 @@ void BundleWriter::HasColor(int srcK, int colorK) { AddRelation(bundlespec::Rel:
 void BundleWriter::OnLevel(int objectK, int levelK) { AddRelation(bundlespec::Rel::ON_LEVEL, objectK, levelK, 0); }
 void BundleWriter::InCollection(int objectK, int collectionK, int ord) { AddRelation(bundlespec::Rel::IN_COLLECTION, objectK, collectionK, ord); }
 void BundleWriter::InModel(int objectK, int modelK, int ord) { AddRelation(bundlespec::Rel::IN_MODEL, objectK, modelK, ord); }
+void BundleWriter::HostedOn(int hostedObjectK, int hostObjectK) { AddRelation(bundlespec::Rel::HOSTED_ON, hostedObjectK, hostObjectK, 0); }
 
 void BundleWriter::AddSceneView(int view, const std::string& name, bool isDefault, const std::vector<SceneViewTier>& tiers)
 {

--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
@@ -588,7 +588,6 @@ void BundleWriter::HasColor(int srcK, int colorK) { AddRelation(bundlespec::Rel:
 void BundleWriter::OnLevel(int objectK, int levelK) { AddRelation(bundlespec::Rel::ON_LEVEL, objectK, levelK, 0); }
 void BundleWriter::InCollection(int objectK, int collectionK, int ord) { AddRelation(bundlespec::Rel::IN_COLLECTION, objectK, collectionK, ord); }
 void BundleWriter::InModel(int objectK, int modelK, int ord) { AddRelation(bundlespec::Rel::IN_MODEL, objectK, modelK, ord); }
-void BundleWriter::HostedOn(int hostedObjectK, int hostObjectK) { AddRelation(bundlespec::Rel::HOSTED_ON, hostedObjectK, hostObjectK, 0); }
 void BundleWriter::InGroup(int objectK, int groupK, int ord) { AddRelation(bundlespec::Rel::IN_GROUP, objectK, groupK, ord); }
 void BundleWriter::InRoom(int objectK, int roomK, int ord) { AddRelation(bundlespec::Rel::IN_ROOM, objectK, roomK, ord); }
 void BundleWriter::Bounds(int boundingObjectK, int roomObjectK, int ord) { AddRelation(bundlespec::Rel::BOUNDS, boundingObjectK, roomObjectK, ord); }

--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
@@ -589,6 +589,7 @@ void BundleWriter::OnLevel(int objectK, int levelK) { AddRelation(bundlespec::Re
 void BundleWriter::InCollection(int objectK, int collectionK, int ord) { AddRelation(bundlespec::Rel::IN_COLLECTION, objectK, collectionK, ord); }
 void BundleWriter::InModel(int objectK, int modelK, int ord) { AddRelation(bundlespec::Rel::IN_MODEL, objectK, modelK, ord); }
 void BundleWriter::HostedOn(int hostedObjectK, int hostObjectK) { AddRelation(bundlespec::Rel::HOSTED_ON, hostedObjectK, hostObjectK, 0); }
+void BundleWriter::InGroup(int objectK, int groupK, int ord) { AddRelation(bundlespec::Rel::IN_GROUP, objectK, groupK, ord); }
 
 void BundleWriter::AddSceneView(int view, const std::string& name, bool isDefault, const std::vector<SceneViewTier>& tiers)
 {

--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.cpp
@@ -590,6 +590,9 @@ void BundleWriter::InCollection(int objectK, int collectionK, int ord) { AddRela
 void BundleWriter::InModel(int objectK, int modelK, int ord) { AddRelation(bundlespec::Rel::IN_MODEL, objectK, modelK, ord); }
 void BundleWriter::HostedOn(int hostedObjectK, int hostObjectK) { AddRelation(bundlespec::Rel::HOSTED_ON, hostedObjectK, hostObjectK, 0); }
 void BundleWriter::InGroup(int objectK, int groupK, int ord) { AddRelation(bundlespec::Rel::IN_GROUP, objectK, groupK, ord); }
+void BundleWriter::InRoom(int objectK, int roomK, int ord) { AddRelation(bundlespec::Rel::IN_ROOM, objectK, roomK, ord); }
+void BundleWriter::Bounds(int boundingObjectK, int roomObjectK, int ord) { AddRelation(bundlespec::Rel::BOUNDS, boundingObjectK, roomObjectK, ord); }
+void BundleWriter::ConnectsTo(int sourceObjectK, int targetObjectK, int scope) { AddRelation(bundlespec::Rel::CONNECTS_TO, sourceObjectK, targetObjectK, scope); }
 
 void BundleWriter::AddSceneView(int view, const std::string& name, bool isDefault, const std::vector<SceneViewTier>& tiers)
 {

--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
@@ -88,11 +88,6 @@ public:
     void InCollection(int objectK, int collectionK, int ord);
     void InModel(int objectK, int modelK, int ord);
 
-    // Hosted element -> its host (door/window -> wall, skylight -> roof/shell). A
-    // DIFFERENT semantic from Subelement: an opening is placed ON its host, not a
-    // component of it. Emit only when both endpoints are objects that were sent.
-    void HostedOn(int hostedObjectK, int hostObjectK);
-
     // Authored group membership -> CONTAINER(subtype "Group"). A SEPARATE axis from
     // InCollection (the layer scene-tree, single-valued on receive): an object keeps its
     // layer AND its group(s).

--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
@@ -88,6 +88,11 @@ public:
     void InCollection(int objectK, int collectionK, int ord);
     void InModel(int objectK, int modelK, int ord);
 
+    // Hosted element -> its host (door/window -> wall, skylight -> roof/shell). A
+    // DIFFERENT semantic from Subelement: an opening is placed ON its host, not a
+    // component of it. Emit only when both endpoints are objects that were sent.
+    void HostedOn(int hostedObjectK, int hostObjectK);
+
     // ── scene views ───────────────────────────────────────────────────
     void AddSceneView(int view, const std::string& name, bool isDefault, const std::vector<SceneViewTier>& tiers);
 

--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
@@ -98,6 +98,19 @@ public:
     // layer AND its group(s).
     void InGroup(int objectK, int groupK, int ord);
 
+    // Spatial occupancy: element -> the ZONE object containing it. Zones ship as objects
+    // (their geometry is the zone volume), so roomK is an object K, not a node.
+    void InRoom(int objectK, int roomK, int ord);
+
+    // A room-bounding element -> the ZONE object it bounds (the zone footprint).
+    void Bounds(int boundingObjectK, int roomObjectK, int ord);
+
+    // Object -> object connectivity, DIRECTED src->dst. `scope` tags which connectivity
+    // graph the edge belongs to — CONNECTS_TO uses ord as a SCOPE, not an ordinal
+    // (rel_types.ord_semantics = 'scope'). For zone adjacency the scope is the connecting
+    // opening's object K; 0 means unscoped.
+    void ConnectsTo(int sourceObjectK, int targetObjectK, int scope);
+
     // ── scene views ───────────────────────────────────────────────────
     void AddSceneView(int view, const std::string& name, bool isDefault, const std::vector<SceneViewTier>& tiers);
 

--- a/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
+++ b/AddOns/Speckle/Sources/AddOn/Artifacts/BundleWriter.h
@@ -93,6 +93,11 @@ public:
     // component of it. Emit only when both endpoints are objects that were sent.
     void HostedOn(int hostedObjectK, int hostObjectK);
 
+    // Authored group membership -> CONTAINER(subtype "Group"). A SEPARATE axis from
+    // InCollection (the layer scene-tree, single-valued on receive): an object keeps its
+    // layer AND its group(s).
+    void InGroup(int objectK, int groupK, int ord);
+
     // ── scene views ───────────────────────────────────────────────────
     void AddSceneView(int view, const std::string& name, bool isDefault, const std::vector<SceneViewTier>& tiers);
 

--- a/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
@@ -127,6 +127,18 @@ namespace
             writer.InCollection(objK, layerK, 0);
         }
 
+        // Group membership -> CONTAINER(subtype "Group") + IN_GROUP. A SEPARATE axis from
+        // IN_COLLECTION above: an element keeps its layer AND its group, and the receive side
+        // treats the two differently (collection is last-wins because it IS the scene tree;
+        // groups are multi-valued). Groups are emitted FLAT for now — the immediate group only,
+        // no parent chain; see the plan's open questions.
+        if (isTopLevel && !obj.groupId.empty())
+        {
+            const std::string groupName = CONNECTOR.GetHostToSpeckleConverter().GetGroupDisplayName(obj.groupId);
+            const int groupK = writer.AddContainer(obj.groupId, groupName, nullptr, "Group");
+            writer.InGroup(objK, groupK, 0);
+        }
+
         if (obj.instance.valid)
         {
             // Instanced GDL/library-part object: shared DEFINITION + per-placement INSTANCE.

--- a/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
@@ -37,6 +37,10 @@ namespace
 
         // (hosted element guid, host element guid) — door/window -> wall, skylight -> roof/shell.
         std::vector<std::pair<std::string, std::string>> hostedPairs;
+
+        // (zone guid, its spatial relations) and (opening guid, the two zones it connects).
+        std::vector<std::pair<std::string, ArchicadRoomTopology>> zoneTopology;
+        std::vector<std::pair<std::string, ArchicadRoomTopology>> openingTopology;
     };
 
     // Resolves (and caches) the MATERIAL node for a Modeler material index.
@@ -96,6 +100,11 @@ namespace
         // be in the selection at all.
         if (!obj.hostElementId.empty())
             ctx.hostedPairs.emplace_back(obj.applicationId, obj.hostElementId);
+
+        if (!obj.roomInfo.occupantElementIds.empty() || !obj.roomInfo.boundingElementIds.empty())
+            ctx.zoneTopology.emplace_back(obj.applicationId, obj.roomInfo);
+        if (!obj.roomInfo.fromRoomId.empty() && !obj.roomInfo.toRoomId.empty())
+            ctx.openingTopology.emplace_back(obj.applicationId, obj.roomInfo);
 
         // Root scalars mirror the eav root-scalar fields the SDK indexes
         // (speckle_type/name/type/level/units — same set Revit emits, minus category/family).
@@ -179,14 +188,52 @@ namespace
     // than a dangling reference into an object that carries no data.
     void EmitDeferredTopology(BundleWriter& writer, const EmitContext& ctx)
     {
+        // Resolves an applicationId to its object K, or nullptr when that element was not
+        // among the sent objects.
+        const auto resolve = [&ctx](const std::string& appId) -> const int*
+        {
+            const auto it = ctx.objectKByAppId.find(appId);
+            return it == ctx.objectKByAppId.end() ? nullptr : &it->second;
+        };
+
         for (const auto& [hostedAppId, hostAppId] : ctx.hostedPairs)
         {
-            const auto hosted = ctx.objectKByAppId.find(hostedAppId);
-            const auto host = ctx.objectKByAppId.find(hostAppId);
-            if (hosted == ctx.objectKByAppId.end() || host == ctx.objectKByAppId.end())
+            const int* hosted = resolve(hostedAppId);
+            const int* host = resolve(hostAppId);
+            if (hosted != nullptr && host != nullptr)
+                writer.HostedOn(*hosted, *host);
+        }
+
+        for (const auto& [zoneAppId, topology] : ctx.zoneTopology)
+        {
+            const int* zoneK = resolve(zoneAppId);
+            if (zoneK == nullptr)
                 continue;
 
-            writer.HostedOn(hosted->second, host->second);
+            for (const auto& occupantId : topology.occupantElementIds)
+            {
+                if (const int* occupantK = resolve(occupantId))
+                    writer.InRoom(*occupantK, *zoneK, 0);
+            }
+
+            int boundsOrd = 0;
+            for (const auto& boundingId : topology.boundingElementIds)
+            {
+                if (const int* boundingK = resolve(boundingId))
+                    writer.Bounds(*boundingK, *zoneK, boundsOrd++);
+            }
+        }
+
+        // Zone adjacency: the two zones an opening joins, scoped by the opening itself so a
+        // consumer can tell WHICH door connects a given pair (CONNECTS_TO's ord is a scope
+        // tag, not an ordinal).
+        for (const auto& [openingAppId, topology] : ctx.openingTopology)
+        {
+            const int* openingK = resolve(openingAppId);
+            const int* fromK = resolve(topology.fromRoomId);
+            const int* toK = resolve(topology.toRoomId);
+            if (openingK != nullptr && fromK != nullptr && toK != nullptr)
+                writer.ConnectsTo(*fromK, *toK, *openingK);
         }
     }
 }

--- a/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
@@ -103,6 +103,16 @@ namespace
             writer.OnLevel(objK, levelK);
         }
 
+        // Layer membership -> CONTAINER(subtype "Collection") + IN_COLLECTION, the authored
+        // scene-tree axis. Archicad layers are flat, so the container never gets a parent.
+        // Children inherit the parent's layer (openings take their host's), so only top-level
+        // objects carry the edge — same rule as ON_LEVEL above.
+        if (isTopLevel && !obj.layerInfo.id.empty())
+        {
+            const int layerK = writer.AddCollection(obj.layerInfo.id, obj.layerInfo.name, nullptr, "Collection");
+            writer.InCollection(objK, layerK, 0);
+        }
+
         if (obj.instance.valid)
         {
             // Instanced GDL/library-part object: shared DEFINITION + per-placement INSTANCE.
@@ -221,10 +231,12 @@ NativeSendResult ArchicadArtifactRootObjectBuilder::BuildAndUpload(
                 throw UserCancelledException("The user cancelled the send operation");
         }
 
-        // 3. Default explorer projection: Story (ON_LEVEL) -> Element type (eav "type") —
-        //    the same hierarchy the old nested Level/ElementTypeCollection tree encoded.
+        // 3. Default explorer projection: Story (ON_LEVEL) -> Layer (IN_COLLECTION) ->
+        //    Element type (eav "type"). Layer sits between them because that is how
+        //    Archicad users navigate a storey; the type tier stays innermost.
         writer.AddSceneView(0, "Default", true, {
             { "rel", std::to_string(static_cast<int>(bundlespec::Rel::ON_LEVEL)) },
+            { "rel", std::to_string(static_cast<int>(bundlespec::Rel::IN_COLLECTION)) },
             { "eav", "type" },
         });
 

--- a/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
@@ -36,7 +36,13 @@ namespace
         std::unordered_map<std::string, int> objectKByAppId; // every emitted object, by applicationId
 
         // (hosted element guid, host element guid) — door/window -> wall, skylight -> roof/shell.
+        // Emitted as SUBELEMENT host->hosted; see EmitDeferredTopology.
         std::vector<std::pair<std::string, std::string>> hostedPairs;
+
+        // Next SUBELEMENT ordinal per parent object K. Shared by the child walk and the
+        // deferred hosting pass so a curtain wall that also hosts a door does not hand out
+        // the same ordinal twice.
+        std::unordered_map<int, int> nextSubelementOrd;
 
         // (zone guid, its spatial relations) and (opening guid, the two zones it connects).
         std::vector<std::pair<std::string, ArchicadRoomTopology>> zoneTopology;
@@ -171,12 +177,11 @@ namespace
             }
         }
 
-        // Hosted/nested children (beam & column segments today) -> SUBELEMENT edges.
-        int subOrd = 0;
+        // Nested children (beam/column segments, curtain wall parts) -> SUBELEMENT edges.
         for (const auto& child : obj.elements)
         {
             const int childK = EmitObject(writer, ctx, child, false);
-            writer.Subelement(objK, childK, subOrd++);
+            writer.Subelement(objK, childK, ctx.nextSubelementOrd[objK]++);
         }
 
         return objK;
@@ -186,7 +191,7 @@ namespace
     // whole selection had been emitted. Every edge is guarded on BOTH endpoints being sent
     // objects — an opening whose wall is not in the selection simply gets no edge, rather
     // than a dangling reference into an object that carries no data.
-    void EmitDeferredTopology(BundleWriter& writer, const EmitContext& ctx)
+    void EmitDeferredTopology(BundleWriter& writer, EmitContext& ctx)
     {
         // Resolves an applicationId to its object K, or nullptr when that element was not
         // among the sent objects.
@@ -196,12 +201,22 @@ namespace
             return it == ctx.objectKByAppId.end() ? nullptr : &it->second;
         };
 
+        // Hosting -> SUBELEMENT, directed HOST -> HOSTED, matching the Revit connector
+        // (RevitArtifactRootObjectBuilder.EmitElementTopology does
+        // pipeline.Subelement(parentK, elementK) for FamilyInstance.Host ?? .SuperComponent).
+        //
+        // The spec has a dedicated HOSTED_ON (22) whose semantics fit better — an opening is
+        // placed ON a wall rather than being a component of it — but NO connector emits it,
+        // and the .NET receive side has no map for it. A door reading as a wall's child in
+        // every client beats a semantically purer edge that nothing consumes. Direction
+        // matters: the viewer labels SUBELEMENT by direction ("children" outgoing from the
+        // wall, "host" incoming on the door), which HOSTED_ON's reversed src/dst would invert.
         for (const auto& [hostedAppId, hostAppId] : ctx.hostedPairs)
         {
             const int* hosted = resolve(hostedAppId);
             const int* host = resolve(hostAppId);
             if (hosted != nullptr && host != nullptr)
-                writer.HostedOn(*hosted, *host);
+                writer.Subelement(*host, *hosted, ctx.nextSubelementOrd[*host]++);
         }
 
         for (const auto& [zoneAppId, topology] : ctx.zoneTopology)

--- a/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
@@ -234,10 +234,21 @@ NativeSendResult ArchicadArtifactRootObjectBuilder::BuildAndUpload(
         //    names, ...) cached across elements for the duration of the loop.
         session.BeginPhase("CollectAndWrite");
         ConverterUtils::SendCacheScope sendCacheScope;
-        processWindow.SetNextProcessPhase("Converting elements", static_cast<int>(elementIds.size()));
+
+        // Drop sub-elements whose hierarchical parent is also selected — they are emitted as
+        // that parent's SUBELEMENT children, so sending them again at top level would
+        // duplicate their geometry and properties. A single element-type filter returns both
+        // tiers ("CurtainWall" -> the wall AND its frames/panels/...), which is exactly when
+        // this bites.
+        const std::vector<std::string> topLevelIds =
+            CONNECTOR.GetHostToSpeckleConverter().FilterOutHierarchicalChildren(elementIds);
+        const size_t foldedIntoParents = elementIds.size() - topLevelIds.size();
+        session.SetStat("foldedIntoParents", static_cast<long long>(foldedIntoParents));
+
+        processWindow.SetNextProcessPhase("Converting elements", static_cast<int>(topLevelIds.size()));
         EmitContext ctx;
         int elemCount = 0;
-        for (const auto& elemId : elementIds)
+        for (const auto& elemId : topLevelIds)
         {
             elemCount++;
             processWindow.SetProcessValue(elemCount);

--- a/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Connector/ArchicadArtifactRootObjectBuilder.cpp
@@ -21,6 +21,24 @@
 
 namespace
 {
+    // Mutable state threaded through the emit walk.
+    //
+    // Beyond the interning caches it collects the object->object edges that CANNOT be
+    // written during the walk: an edge may only be emitted once both endpoints are known
+    // to be sent objects, and the far endpoint may not have been reached yet (or may not
+    // be in the selection at all). Interning an unsent guid would mint a phantom object
+    // row with no properties and no geometry, so these are resolved in a second pass
+    // against objectKByAppId. Mirrors the Revit builder's objectKsByElementUniqueId.
+    struct EmitContext
+    {
+        std::unordered_map<int, int> materialCache;          // Modeler material index -> MATERIAL node K
+        std::unordered_set<std::string> seenDefinitions;     // definitionId whose geometry is written
+        std::unordered_map<std::string, int> objectKByAppId; // every emitted object, by applicationId
+
+        // (hosted element guid, host element guid) — door/window -> wall, skylight -> roof/shell.
+        std::vector<std::pair<std::string, std::string>> hostedPairs;
+    };
+
     // Resolves (and caches) the MATERIAL node for a Modeler material index.
     int GetOrAddMaterialNode(BundleWriter& writer, std::unordered_map<int, int>& cache, int materialIndex)
     {
@@ -39,19 +57,14 @@ namespace
     // Emits the display geometry for an object as an INSTANCE of a shared DEFINITION.
     // The definition (its local-space geometry + material edges) is written once per
     // definitionId; every placement adds only its own INSTANCE node + DISPLAY_INSTANCE edge.
-    void EmitInstance(
-        BundleWriter& writer,
-        std::unordered_map<int, int>& materialCache,
-        std::unordered_set<std::string>& seenDefinitions,
-        int objK,
-        const ArchicadObject& obj)
+    void EmitInstance(BundleWriter& writer, EmitContext& ctx, int objK, const ArchicadObject& obj)
     {
         const std::string& definitionId = obj.instance.definitionId;
         const int defK = writer.AddDefinition(definitionId, obj.name.empty() ? definitionId : obj.name);
 
         // Definition geometry is emitted exactly once. Geometry ids are deterministic per
         // definition ("def:{id}:{i}") so AddGeometrySgeo interns them stably across placements.
-        if (seenDefinitions.insert(definitionId).second)
+        if (ctx.seenDefinitions.insert(definitionId).second)
         {
             int ord = 0;
             for (const auto& mesh : obj.instance.localBody.meshes)
@@ -61,7 +74,7 @@ namespace
                 const int geometryK = writer.AddGeometrySgeo(geometryAppId, sgeo);
                 writer.Defines(defK, geometryK, ord);
 
-                const int materialK = GetOrAddMaterialNode(writer, materialCache, mesh.materialIndex);
+                const int materialK = GetOrAddMaterialNode(writer, ctx.materialCache, mesh.materialIndex);
                 writer.HasMaterial(geometryK, materialK);
                 ord++;
             }
@@ -74,14 +87,15 @@ namespace
 
     // Emits one ArchicadObject (and recursively its children) into the bundle.
     // Returns the object's dense K.
-    int EmitObject(
-        BundleWriter& writer,
-        std::unordered_map<int, int>& materialCache,
-        std::unordered_set<std::string>& seenDefinitions,
-        const ArchicadObject& obj,
-        bool isTopLevel)
+    int EmitObject(BundleWriter& writer, EmitContext& ctx, const ArchicadObject& obj, bool isTopLevel)
     {
         const int objK = writer.InternObject(obj.applicationId);
+        ctx.objectKByAppId[obj.applicationId] = objK;
+
+        // Deferred to the second pass — the host may be emitted later in the loop, or not
+        // be in the selection at all.
+        if (!obj.hostElementId.empty())
+            ctx.hostedPairs.emplace_back(obj.applicationId, obj.hostElementId);
 
         // Root scalars mirror the eav root-scalar fields the SDK indexes
         // (speckle_type/name/type/level/units — same set Revit emits, minus category/family).
@@ -116,7 +130,7 @@ namespace
         if (obj.instance.valid)
         {
             // Instanced GDL/library-part object: shared DEFINITION + per-placement INSTANCE.
-            EmitInstance(writer, materialCache, seenDefinitions, objK, obj);
+            EmitInstance(writer, ctx, objK, obj);
         }
         else
         {
@@ -130,7 +144,7 @@ namespace
                 const int geometryK = writer.AddGeometrySgeo(geometryAppId, sgeo);
                 writer.Display(objK, geometryK, ord);
 
-                const int materialK = GetOrAddMaterialNode(writer, materialCache, mesh.materialIndex);
+                const int materialK = GetOrAddMaterialNode(writer, ctx.materialCache, mesh.materialIndex);
                 writer.HasMaterial(geometryK, materialK);
                 ord++;
             }
@@ -140,11 +154,28 @@ namespace
         int subOrd = 0;
         for (const auto& child : obj.elements)
         {
-            const int childK = EmitObject(writer, materialCache, seenDefinitions, child, false);
+            const int childK = EmitObject(writer, ctx, child, false);
             writer.Subelement(objK, childK, subOrd++);
         }
 
         return objK;
+    }
+
+    // Second pass: object->object edges whose far endpoint could only be resolved once the
+    // whole selection had been emitted. Every edge is guarded on BOTH endpoints being sent
+    // objects — an opening whose wall is not in the selection simply gets no edge, rather
+    // than a dangling reference into an object that carries no data.
+    void EmitDeferredTopology(BundleWriter& writer, const EmitContext& ctx)
+    {
+        for (const auto& [hostedAppId, hostAppId] : ctx.hostedPairs)
+        {
+            const auto hosted = ctx.objectKByAppId.find(hostedAppId);
+            const auto host = ctx.objectKByAppId.find(hostAppId);
+            if (hosted == ctx.objectKByAppId.end() || host == ctx.objectKByAppId.end())
+                continue;
+
+            writer.HostedOn(hosted->second, host->second);
+        }
     }
 }
 
@@ -192,8 +223,7 @@ NativeSendResult ArchicadArtifactRootObjectBuilder::BuildAndUpload(
         session.BeginPhase("CollectAndWrite");
         ConverterUtils::SendCacheScope sendCacheScope;
         processWindow.SetNextProcessPhase("Converting elements", static_cast<int>(elementIds.size()));
-        std::unordered_map<int, int> materialCache;
-        std::unordered_set<std::string> seenDefinitions;
+        EmitContext ctx;
         int elemCount = 0;
         for (const auto& elemId : elementIds)
         {
@@ -206,7 +236,7 @@ NativeSendResult ArchicadArtifactRootObjectBuilder::BuildAndUpload(
             {
                 auto archicadObject =
                     CONNECTOR.GetHostToSpeckleConverter().GetArchicadObject(elemId, conversionResult, includeProperties);
-                EmitObject(writer, materialCache, seenDefinitions, archicadObject, true);
+                EmitObject(writer, ctx, archicadObject, true);
 
                 const double ms =
                     std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - objStart).count();
@@ -231,7 +261,11 @@ NativeSendResult ArchicadArtifactRootObjectBuilder::BuildAndUpload(
                 throw UserCancelledException("The user cancelled the send operation");
         }
 
-        // 3. Default explorer projection: Story (ON_LEVEL) -> Layer (IN_COLLECTION) ->
+        // 3. Object->object topology whose endpoints could only be resolved after the whole
+        //    selection was emitted (HOSTED_ON). Never fails the send.
+        EmitDeferredTopology(writer, ctx);
+
+        // 4. Default explorer projection: Story (ON_LEVEL) -> Layer (IN_COLLECTION) ->
         //    Element type (eav "type"). Layer sits between them because that is how
         //    Archicad users navigate a storey; the type tier stays innermost.
         writer.AddSceneView(0, "Default", true, {
@@ -244,7 +278,7 @@ NativeSendResult ArchicadArtifactRootObjectBuilder::BuildAndUpload(
         session.SetStat("objects", objectCount);
         session.EndPhase();
 
-        // 4. Flush the parquet bundle (one tick per finalized table).
+        // 5. Flush the parquet bundle (one tick per finalized table).
         session.BeginPhase("WriteParquet");
         processWindow.SetNextProcessPhase("Writing bundle", BundleWriter::TableCount());
         auto files = writer.Complete([&](int done, int)
@@ -256,7 +290,7 @@ NativeSendResult ArchicadArtifactRootObjectBuilder::BuildAndUpload(
         session.SetStat("files", static_cast<long long>(files.size()));
         session.EndPhase();
 
-        // 5. Upload: sign -> presigned PUT per file -> complete (creates the version).
+        // 6. Upload: sign -> presigned PUT per file -> complete (creates the version).
         //    UploadFiles drives the "Uploading" (KiB-granular, cancellable) and
         //    "Creating version" phases itself.
         session.BeginPhase("Upload");

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
@@ -12,6 +12,7 @@ ArchicadObject HostToSpeckleConverter::GetArchicadObject(const std::string& elem
     archicadObject.type = GetElementType(elemId);
     archicadObject.levelInfo = GetElementLevel(elemId);
     archicadObject.level = archicadObject.levelInfo.name;
+    archicadObject.layerInfo = GetElementLayer(elemId);
     conversionResult.sourceType = archicadObject.type;
     conversionResult.sourceId = elemId;
 

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
@@ -15,6 +15,7 @@ ArchicadObject HostToSpeckleConverter::GetArchicadObject(const std::string& elem
     archicadObject.layerInfo = GetElementLayer(elemId);
     archicadObject.hostElementId = GetElementHost(elemId);
     archicadObject.groupId = GetElementGroup(elemId);
+    archicadObject.roomInfo = GetElementRoomTopology(elemId);
     conversionResult.sourceType = archicadObject.type;
     conversionResult.sourceId = elemId;
 

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
@@ -14,6 +14,7 @@ ArchicadObject HostToSpeckleConverter::GetArchicadObject(const std::string& elem
     archicadObject.level = archicadObject.levelInfo.name;
     archicadObject.layerInfo = GetElementLayer(elemId);
     archicadObject.hostElementId = GetElementHost(elemId);
+    archicadObject.groupId = GetElementGroup(elemId);
     conversionResult.sourceType = archicadObject.type;
     conversionResult.sourceId = elemId;
 

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetArchicadObject.cpp
@@ -13,6 +13,7 @@ ArchicadObject HostToSpeckleConverter::GetArchicadObject(const std::string& elem
     archicadObject.levelInfo = GetElementLevel(elemId);
     archicadObject.level = archicadObject.levelInfo.name;
     archicadObject.layerInfo = GetElementLayer(elemId);
+    archicadObject.hostElementId = GetElementHost(elemId);
     conversionResult.sourceType = archicadObject.type;
     conversionResult.sourceId = elemId;
 

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementChildren.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementChildren.cpp
@@ -5,51 +5,149 @@
 #include "ACAPinc.h"
 #include "CheckError.h"
 
+#include <unordered_set>
+
 namespace
 {
-	// Owns the memo handles for the duration of the segment walk (the recursive
+	// Owns the memo handles for the duration of the child walk (the recursive
 	// GetArchicadObject calls below can throw).
 	struct MemoGuard
 	{
 		API_ElementMemo memo{};
 		~MemoGuard() { ACAPI_DisposeElemMemoHdls(&memo); }
 	};
+
+	// Appends the guids of one memo sub-part array. Sized from the handle rather than the
+	// element's own count field, matching GetElementBody::GetPartIDs.
+	template<typename T>
+	void CollectGuids(T* parts, std::vector<std::string>& out)
+	{
+		if (parts == nullptr)
+			return;
+
+		const GSSize count = BMGetPtrSize(reinterpret_cast<GSPtr>(parts)) / sizeof(T);
+		for (Int32 i = 0; i < count; ++i)
+			out.push_back(APIGuidToString(parts[i].head.guid).ToCStr().Get());
+	}
+
+	// Memo mask covering exactly the sub-part arrays read below. 0 = the type has no
+	// children and the memo fetch is skipped entirely.
+	UInt64 ChildMemoMask(API_ElemTypeID typeID)
+	{
+		switch (typeID)
+		{
+		case API_BeamID:
+			return APIMemoMask_BeamSegment;
+		case API_ColumnID:
+			return APIMemoMask_ColumnSegment;
+		case API_CurtainWallID:
+			return APIMemoMask_CWallFrames | APIMemoMask_CWallPanels |
+				APIMemoMask_CWallJunctions | APIMemoMask_CWallAccessories;
+		default:
+			return 0;
+		}
+	}
 }
 
+// The element's own child elements, each converted into a full ArchicadObject (its own
+// geometry + properties) and linked to the parent with a SUBELEMENT edge by the caller.
+//
+// NOTE the division of labour with GetElementBody: GetArchicadObject only extracts a body
+// for an element with NO children, so a parent that reports children here contributes no
+// geometry of its own — the children carry all of it. That is what turns a curtain wall
+// from one merged per-material blob into a real parent/child hierarchy, and it is why this
+// function and GetElementBody::CollectPartIDs must not both claim the same parts.
 std::vector<ArchicadObject> HostToSpeckleConverter::GetElementChildren(const std::string& elemId, bool includeProperties)
 {
-	auto elementType = GetElementType(elemId);
-	std::vector<ArchicadObject> children;
-
-	const bool isBeam = (elementType == "Beam");
-	const bool isColumn = (elementType == "Column");
-	if (!isBeam && !isColumn)
-		return children; // only beams/columns have hosted segments — skip the memo fetch
-
 	auto apiElem = ConverterUtils::GetElement(elemId);
-	MemoGuard guard;
-	ACAPI_Element_GetMemo(
-		apiElem.header.guid, &guard.memo, isBeam ? APIMemoMask_BeamSegment : APIMemoMask_ColumnSegment);
-	SendConversionResult segmentConversionResult{};
+	const API_ElemTypeID typeID = apiElem.header.type.typeID;
 
-	if (isBeam && guard.memo.beamSegments != nullptr)
+	const UInt64 memoMask = ChildMemoMask(typeID);
+	if (memoMask == 0)
+		return {};
+
+	MemoGuard guard;
+	ACAPI_Element_GetMemo(apiElem.header.guid, &guard.memo, memoMask);
+
+	std::vector<std::string> childIds;
+	switch (typeID)
 	{
-		for (UInt32 i = 0; i < apiElem.beam.nSegments; i++)
-		{
-			auto segment = (guard.memo.beamSegments)[i];
-			auto segmentId = APIGuidToString(segment.head.guid).ToCStr().Get();
-			children.push_back(GetArchicadObject(segmentId, segmentConversionResult, includeProperties));
-		}
+	case API_BeamID:
+		CollectGuids(guard.memo.beamSegments, childIds);
+		break;
+	case API_ColumnID:
+		CollectGuids(guard.memo.columnSegments, childIds);
+		break;
+	case API_CurtainWallID:
+		// Frames, panels, junctions and accessories are the geometry carriers. SEGMENTS are
+		// deliberately excluded: they are a logical subdivision with no body of their own,
+		// and neither API_CWFrameType nor API_CWPanelType exposes a back-reference to its
+		// segment — so a CW -> segment -> frame tier cannot be reconstructed from the child
+		// side. The hierarchy is therefore flat: curtain wall -> parts.
+		CollectGuids(guard.memo.cWallFrames, childIds);
+		CollectGuids(guard.memo.cWallPanels, childIds);
+		CollectGuids(guard.memo.cWallJunctions, childIds);
+		CollectGuids(guard.memo.cWallAccessories, childIds);
+		break;
+	default:
+		break;
 	}
-	else if (isColumn && guard.memo.columnSegments != nullptr)
-	{
-		for (UInt32 i = 0; i < apiElem.column.nSegments; i++)
-		{
-			auto segment = (guard.memo.columnSegments)[i];
-			auto segmentId = APIGuidToString(segment.head.guid).ToCStr().Get();
-			children.push_back(GetArchicadObject(segmentId, segmentConversionResult, includeProperties));
-		}
-	}
+
+	std::vector<ArchicadObject> children;
+	children.reserve(childIds.size());
+
+	SendConversionResult childConversionResult{};
+	for (const auto& childId : childIds)
+		children.push_back(GetArchicadObject(childId, childConversionResult, includeProperties));
 
 	return children;
+}
+
+// Drops elements whose hierarchical parent is ALSO in the list — they are emitted as
+// SUBELEMENT children of that parent, so sending them again at top level would duplicate
+// both their geometry and their properties.
+//
+// This is needed because GetElementList maps a single type filter onto the parent AND its
+// sub-types (e.g. "CurtainWall" -> API_CurtainWallID plus Segment/Frame/Panel/Junction/
+// Accessory ids; likewise "Stair" and "Railing"), so picking one type filter returns both
+// tiers. The Revit connector solves the same problem with
+// RemoveKnownChildElementsWhenParentPresent.
+//
+// The test is "the API reports an owner that is not the element itself, and that owner is
+// in the selection". ACAPI_HierarchicalEditing_GetHierarchicalElementOwner returns the
+// INPUT element as the owner when it is not a child, so comparing against self is the
+// robust check — more so than trusting API_ChildElemInMultipleElem, which is documented
+// only for curtain walls / stairs / railings and may not classify beam and column
+// segments. A child whose parent is NOT in the selection is kept and sent standalone.
+std::vector<std::string> HostToSpeckleConverter::FilterOutHierarchicalChildren(const std::vector<std::string>& elementIds)
+{
+	const std::unordered_set<std::string> present(elementIds.begin(), elementIds.end());
+
+	std::vector<std::string> kept;
+	kept.reserve(elementIds.size());
+
+	for (const auto& elemId : elementIds)
+	{
+		API_Guid guid = APIGuidFromString(elemId.c_str());
+		const API_HierarchicalOwnerType ownerType = API_RootHierarchicalOwner;
+		API_HierarchicalElemType hierarchicalElemType = API_UnknownElemType;
+		API_Guid ownerGuid = APINULLGuid;
+
+		const GSErrCode err = ACAPI_HierarchicalEditing_GetHierarchicalElementOwner(
+			&guid, &ownerType, &hierarchicalElemType, &ownerGuid);
+
+		// Unknown ownership -> keep. Dropping an element we cannot classify would silently
+		// lose it; a duplicate is the safer failure.
+		if (err != NoError || ownerGuid == APINULLGuid || ownerGuid == guid)
+		{
+			kept.push_back(elemId);
+			continue;
+		}
+
+		const std::string ownerId = APIGuidToString(ownerGuid).ToCStr().Get();
+		if (present.find(ownerId) == present.end())
+			kept.push_back(elemId);
+	}
+
+	return kept;
 }

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementGroup.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementGroup.cpp
@@ -1,0 +1,39 @@
+#include "HostToSpeckleConverter.h"
+#include "ConverterUtils.h"
+
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+
+// The group this element belongs to, straight off the element header — no ACAPI
+// round-trip. APINULLGuid means ungrouped (also the case for non-groupable element
+// types), which is the signal to emit no IN_GROUP edge.
+//
+// This is the IMMEDIATE group, not the root of a nested group chain
+// (ACAPI_Grouping_GetRootGroup would give that). The immediate group is the more specific
+// answer and is what a flat IN_GROUP axis wants; nesting is a follow-up, see
+// GetGroupDisplayName below.
+std::string HostToSpeckleConverter::GetElementGroup(const std::string& elemId)
+{
+	auto apiElem = ConverterUtils::GetElement(elemId);
+
+	if (apiElem.header.groupGuid == APINULLGuid)
+		return "";
+
+	return APIGuidToString(apiElem.header.groupGuid).ToCStr().Get();
+}
+
+// Archicad groups are ANONYMOUS: API_GroupID exists as an element type id but there is no
+// API_GroupType in the API_Element union and no name field anywhere — unlike Revit, where
+// a group carries its GroupType name. So there is nothing to display and we synthesise a
+// stable short label from the guid. An unlabelled node in a scene tree is worse than a
+// synthetic one.
+std::string HostToSpeckleConverter::GetGroupDisplayName(const std::string& groupId)
+{
+	if (groupId.empty())
+		return "";
+
+	// Guid strings are "BC1E7D39-C7F9-...."; the first block is short and unique enough
+	// to tell two groups apart in a tree.
+	const std::string shortId = groupId.substr(0, groupId.find('-'));
+	return "Group " + shortId;
+}

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementHost.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementHost.cpp
@@ -11,10 +11,11 @@
 // ACAPI round-trip. API_DoorType is a typedef of API_WindowType, so both read `.owner`
 // off their respective union members.
 //
-// This is deliberately NOT the same relation as SUBELEMENT. Archicad draws the same line
-// the bundle spec does: an opening is PLACED ON its host (owner guid -> HOSTED_ON),
-// whereas a curtain-wall frame or stair tread is a COMPONENT OF its parent
-// (ACAPI_HierarchicalEditing_GetHierarchicalElementOwner -> SUBELEMENT).
+// The caller turns this into a SUBELEMENT edge directed HOST -> HOSTED, matching the Revit
+// connector. Archicad's API does distinguish hosting (this `owner` guid) from composition
+// (ACAPI_HierarchicalEditing_GetHierarchicalElementOwner, used by FilterOutHierarchicalChildren),
+// and the spec has a separate HOSTED_ON (22) for the former — but no connector emits it, so
+// both collapse onto SUBELEMENT here. See EmitDeferredTopology for the reasoning.
 std::string HostToSpeckleConverter::GetElementHost(const std::string& elemId)
 {
 	auto apiElem = ConverterUtils::GetElement(elemId);

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementHost.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementHost.cpp
@@ -1,0 +1,42 @@
+#include "HostToSpeckleConverter.h"
+#include "ConverterUtils.h"
+
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+
+// The element this one is HOSTED ON: a door/window's container wall, a skylight's
+// container roof or shell. Empty for everything else.
+//
+// The owner guid rides in the element struct we already fetched, so this costs no extra
+// ACAPI round-trip. API_DoorType is a typedef of API_WindowType, so both read `.owner`
+// off their respective union members.
+//
+// This is deliberately NOT the same relation as SUBELEMENT. Archicad draws the same line
+// the bundle spec does: an opening is PLACED ON its host (owner guid -> HOSTED_ON),
+// whereas a curtain-wall frame or stair tread is a COMPONENT OF its parent
+// (ACAPI_HierarchicalEditing_GetHierarchicalElementOwner -> SUBELEMENT).
+std::string HostToSpeckleConverter::GetElementHost(const std::string& elemId)
+{
+	auto apiElem = ConverterUtils::GetElement(elemId);
+
+	API_Guid owner = APINULLGuid;
+	switch (apiElem.header.type.typeID)
+	{
+	case API_WindowID:
+		owner = apiElem.window.owner;
+		break;
+	case API_DoorID:
+		owner = apiElem.door.owner;
+		break;
+	case API_SkylightID:
+		owner = apiElem.skylight.owner;
+		break;
+	default:
+		return "";
+	}
+
+	if (owner == APINULLGuid)
+		return "";
+
+	return APIGuidToString(owner).ToCStr().Get();
+}

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementLayer.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementLayer.cpp
@@ -1,0 +1,29 @@
+#include "HostToSpeckleConverter.h"
+#include "ConverterUtils.h"
+
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+
+// The element's layer, straight off the element header — no extra ACAPI round-trip for
+// the index itself. Only the index -> name resolution costs a call, and that goes through
+// ConverterUtils::GetAttributeName, which is cached by (attribute type, index) per send.
+//
+// NOT built on GetLayers(): that one brute-forces indices 1..32768 with an
+// ACAPI_Attribute_Get each (it works around ACAPI_Attribute_GetNum under-reporting) and is
+// sized for a one-shot filter populate, not a per-element lookup.
+ArchicadLayer HostToSpeckleConverter::GetElementLayer(const std::string& elemId)
+{
+	ArchicadLayer layer;
+
+	auto apiElem = ConverterUtils::GetElement(elemId);
+	const API_AttributeIndex& layerIndex = apiElem.header.layer;
+
+	// APIInvalidAttributeIndex == 0. Non-groupable / layerless elements land here and
+	// simply get no IN_COLLECTION edge.
+	if (!layerIndex.IsPositive())
+		return layer;
+
+	layer.id = layerIndex.ToUniString().ToCStr().Get();
+	layer.name = ConverterUtils::GetAttributeName(layerIndex, API_LayerID);
+	return layer;
+}

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementRoomTopology.cpp
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/GetElementRoomTopology.cpp
@@ -1,0 +1,107 @@
+#include "HostToSpeckleConverter.h"
+#include "ConverterUtils.h"
+
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+
+namespace
+{
+	// Which element types count as OCCUPYING a zone rather than bounding or intersecting it.
+	//
+	// API_RoomRelation::elementsGroupedByType returns everything related to the room —
+	// including the walls, slabs, roofs and shells that ENCLOSE it. Emitting IN_ROOM for
+	// those would say a wall "occupies" the room, which is wrong: enclosure is what BOUNDS
+	// is for. So occupancy is an explicit allowlist rather than a denylist, and it lands on
+	// roughly the same set Revit's FamilyInstance.Room covers (furniture / lamps / openings),
+	// plus the free-standing element types.
+	const API_ElemTypeID s_occupantTypes[] = {
+		API_ObjectID,
+		API_LampID,
+		API_WindowID,
+		API_DoorID,
+		API_StairID,
+		API_RailingID,
+		API_MorphID,
+		API_ColumnID,
+	};
+
+	void AppendGuids(const GS::Array<API_Guid>& guids, std::vector<std::string>& out)
+	{
+		for (const auto& guid : guids)
+			out.push_back(APIGuidToString(guid).ToCStr().Get());
+	}
+
+	// Owns the room-relation handles; the struct carries handle-backed arrays that the API
+	// requires us to release through its own disposer.
+	struct RoomRelationGuard
+	{
+		API_RoomRelation relation{};
+		~RoomRelationGuard() { ACAPI_DisposeRoomRelationHdls(&relation); }
+	};
+
+	ArchicadRoomTopology GetZoneTopology(const API_Guid& zoneGuid)
+	{
+		ArchicadRoomTopology topology;
+
+		RoomRelationGuard guard;
+		// API_ZombieElemID = "every related type", so one call returns occupants AND the
+		// bordering wall parts.
+		if (ACAPI_Element_GetRelations(zoneGuid, API_ZombieElemID, &guard.relation) != NoError)
+			return topology;
+
+		for (const API_ElemTypeID typeID : s_occupantTypes)
+		{
+			if (const GS::Array<API_Guid>* guids = guard.relation.elementsGroupedByType.GetPtr(typeID))
+				AppendGuids(*guids, topology.occupantElementIds);
+		}
+
+		// wallPart holds the wall segments that border the zone polygon. cwSegmentPart is
+		// deliberately NOT read: it identifies curtain wall SEGMENTS, which are not emitted as
+		// objects (see GetElementChildren — segments carry no body and have no back-reference
+		// from frames/panels), so such an edge could never resolve to a sent object.
+		for (const auto& wallPart : guard.relation.wallPart)
+			topology.boundingElementIds.push_back(APIGuidToString(wallPart.guid).ToCStr().Get());
+
+		return topology;
+	}
+
+	// Doors, windows and skylights report the zones on either side directly — the exact
+	// analogue of Revit's FamilyInstance.FromRoom / .ToRoom. No derivation from wall
+	// adjacency needed.
+	ArchicadRoomTopology GetOpeningTopology(const API_Guid& openingGuid)
+	{
+		ArchicadRoomTopology topology;
+
+		// API_WindowRelation / API_DoorRelation / API_SkylightRelation are all aliases of
+		// API_CWPanelRelation: two plain guids, no handles, so nothing to dispose.
+		API_CWPanelRelation relation{};
+		if (ACAPI_Element_GetRelations(openingGuid, API_ZoneID, &relation) != NoError)
+			return topology;
+
+		if (relation.fromRoom != APINULLGuid)
+			topology.fromRoomId = APIGuidToString(relation.fromRoom).ToCStr().Get();
+		if (relation.toRoom != APINULLGuid)
+			topology.toRoomId = APIGuidToString(relation.toRoom).ToCStr().Get();
+
+		return topology;
+	}
+}
+
+// Spatial topology for one element: what a zone contains and what bounds it, or which two
+// zones an opening connects. Empty for every other element type.
+ArchicadRoomTopology HostToSpeckleConverter::GetElementRoomTopology(const std::string& elemId)
+{
+	auto apiElem = ConverterUtils::GetElement(elemId);
+
+	switch (apiElem.header.type.typeID)
+	{
+	case API_ZoneID:
+		return GetZoneTopology(apiElem.header.guid);
+	case API_WindowID:
+	case API_DoorID:
+	case API_SkylightID:
+		return GetOpeningTopology(apiElem.header.guid);
+	default:
+		return {};
+	}
+}

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
@@ -35,6 +35,7 @@ public:
 	WorkingUnits GetWorkingUnits() override;
 	ArchicadObject GetArchicadObject(const std::string& elemId, SendConversionResult& conversionResult, bool includeProperties) override;
 	std::vector<ArchicadObject> GetElementChildren(const std::string& elemId, bool includeProperties) override;
+	std::vector<std::string> FilterOutHierarchicalChildren(const std::vector<std::string>& elementIds) override;
 	std::string GetResourceString(short resourceId) override;
 	std::vector<NavigatorView> GetNavigatorViews() override;
 	std::vector<LayerData> GetLayers() override;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
@@ -17,6 +17,7 @@ public:
 	Material GetModelMaterial(int materialIndex) override;
 	std::string GetElementName(const std::string& elemId) override;
 	ArchicadLevel GetElementLevel(const std::string& elemId) override;
+	ArchicadLayer GetElementLayer(const std::string& elemId) override;
 	std::string GetElementType(const std::string& elemId) override;
 	std::map<std::string, std::string> GetElementClassifications(const std::string& elemId) override;
 	ProjectInfo GetProjectInfo() override;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
@@ -21,6 +21,7 @@ public:
 	std::string GetElementHost(const std::string& elemId) override;
 	std::string GetElementGroup(const std::string& elemId) override;
 	std::string GetGroupDisplayName(const std::string& groupId) override;
+	ArchicadRoomTopology GetElementRoomTopology(const std::string& elemId) override;
 	std::string GetElementType(const std::string& elemId) override;
 	std::map<std::string, std::string> GetElementClassifications(const std::string& elemId) override;
 	ProjectInfo GetProjectInfo() override;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
@@ -19,6 +19,8 @@ public:
 	ArchicadLevel GetElementLevel(const std::string& elemId) override;
 	ArchicadLayer GetElementLayer(const std::string& elemId) override;
 	std::string GetElementHost(const std::string& elemId) override;
+	std::string GetElementGroup(const std::string& elemId) override;
+	std::string GetGroupDisplayName(const std::string& groupId) override;
 	std::string GetElementType(const std::string& elemId) override;
 	std::map<std::string, std::string> GetElementClassifications(const std::string& elemId) override;
 	ProjectInfo GetProjectInfo() override;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/HostToSpeckleConverter.h
@@ -18,6 +18,7 @@ public:
 	std::string GetElementName(const std::string& elemId) override;
 	ArchicadLevel GetElementLevel(const std::string& elemId) override;
 	ArchicadLayer GetElementLayer(const std::string& elemId) override;
+	std::string GetElementHost(const std::string& elemId) override;
 	std::string GetElementType(const std::string& elemId) override;
 	std::map<std::string, std::string> GetElementClassifications(const std::string& elemId) override;
 	ProjectInfo GetProjectInfo() override;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
@@ -50,6 +50,9 @@ public:
 	virtual WorkingUnits GetWorkingUnits() = 0;
 	virtual ArchicadObject GetArchicadObject(const std::string& elemId, SendConversionResult& conversionResult, bool includeProperties) = 0;
 	virtual std::vector<ArchicadObject> GetElementChildren(const std::string& elemId, bool includeProperties) = 0;
+	// Drops elements whose hierarchical parent is also in the list — they ship as
+	// SUBELEMENT children of that parent instead of duplicating at top level.
+	virtual std::vector<std::string> FilterOutHierarchicalChildren(const std::vector<std::string>& elementIds) = 0;
 	virtual std::string GetResourceString(short resourceId) = 0;
 	virtual std::vector<NavigatorView> GetNavigatorViews() = 0;
 	virtual std::vector<LayerData> GetLayers() = 0;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
@@ -9,6 +9,7 @@
 #include "PropertyFilters.h"
 #include "NavigatorView.h"
 #include "ArchicadLevel.h"
+#include "ArchicadRoomTopology.h"
 #include "LayerData.h"
 
 class IHostToSpeckleConverter 
@@ -34,6 +35,8 @@ public:
 	virtual std::string GetElementGroup(const std::string& elemId) = 0;
 	// Synthetic display label for a group (Archicad groups carry no name).
 	virtual std::string GetGroupDisplayName(const std::string& groupId) = 0;
+	// Zone occupancy/boundary, or the two zones an opening connects. Empty otherwise.
+	virtual ArchicadRoomTopology GetElementRoomTopology(const std::string& elemId) = 0;
 	virtual std::string GetElementType(const std::string& elemId) = 0;
 	virtual std::map<std::string, std::string> GetElementClassifications(const std::string& elemId) = 0;
 	virtual ProjectInfo GetProjectInfo() = 0;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
@@ -30,6 +30,10 @@ public:
 	// Guid of the element this one is hosted on (door/window -> wall, skylight ->
 	// roof/shell); empty when the element is not an opening.
 	virtual std::string GetElementHost(const std::string& elemId) = 0;
+	// Guid of the group the element belongs to; empty when ungrouped.
+	virtual std::string GetElementGroup(const std::string& elemId) = 0;
+	// Synthetic display label for a group (Archicad groups carry no name).
+	virtual std::string GetGroupDisplayName(const std::string& groupId) = 0;
 	virtual std::string GetElementType(const std::string& elemId) = 0;
 	virtual std::map<std::string, std::string> GetElementClassifications(const std::string& elemId) = 0;
 	virtual ProjectInfo GetProjectInfo() = 0;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
@@ -27,6 +27,9 @@ public:
 	virtual std::string GetElementName(const std::string& elemId) = 0;
 	virtual ArchicadLevel GetElementLevel(const std::string& elemId) = 0;
 	virtual ArchicadLayer GetElementLayer(const std::string& elemId) = 0;
+	// Guid of the element this one is hosted on (door/window -> wall, skylight ->
+	// roof/shell); empty when the element is not an opening.
+	virtual std::string GetElementHost(const std::string& elemId) = 0;
 	virtual std::string GetElementType(const std::string& elemId) = 0;
 	virtual std::map<std::string, std::string> GetElementClassifications(const std::string& elemId) = 0;
 	virtual ProjectInfo GetProjectInfo() = 0;

--- a/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
+++ b/AddOns/Speckle/Sources/AddOn/Converter/HostToSpeckle/IHostToSpeckleConverter.h
@@ -26,6 +26,7 @@ public:
 	virtual Material GetModelMaterial(int materialIndex) = 0;
 	virtual std::string GetElementName(const std::string& elemId) = 0;
 	virtual ArchicadLevel GetElementLevel(const std::string& elemId) = 0;
+	virtual ArchicadLayer GetElementLayer(const std::string& elemId) = 0;
 	virtual std::string GetElementType(const std::string& elemId) = 0;
 	virtual std::map<std::string, std::string> GetElementClassifications(const std::string& elemId) = 0;
 	virtual ProjectInfo GetProjectInfo() = 0;

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadLayer.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadLayer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+// The layer attribute an element sits on, resolved from API_Elem_Head::layer.
+//
+// Archicad layers are FLAT — there is no layer hierarchy (Layer Combinations are a
+// separate, orthogonal concept) — so the bundle CONTAINER built from this never gets
+// a parent. id is empty when the element carries no valid layer
+// (APIInvalidAttributeIndex == 0), which is the signal to emit no IN_COLLECTION edge.
+struct ArchicadLayer
+{
+    std::string id = "";   // layer attribute index as text (matches LayerData::id)
+    std::string name = "";
+};

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
@@ -20,6 +20,11 @@ struct ArchicadObject
     ArchicadLevel levelInfo;
     ArchicadLayer layerInfo;
 
+    // Guid of the element this one is hosted on (door/window -> wall, skylight ->
+    // roof/shell). Empty when not an opening. Resolved to a HOSTED_ON edge after the
+    // main emit loop, once it is known whether the host was itself converted.
+    std::string hostElementId = "";
+
     // Populated (valid == true) only for GDL/library-part "Object" leaves that were
     // extracted as an instance. When valid, displayValue is left empty and the object
     // is emitted as an INSTANCE of a shared DEFINITION rather than baked geometry.

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
@@ -5,6 +5,7 @@
 #include "ElementBody.h"
 #include "ArchicadLevel.h"
 #include "ArchicadLayer.h"
+#include "ArchicadRoomTopology.h"
 #include "ObjectInstance.h"
 
 struct ArchicadObject
@@ -28,6 +29,10 @@ struct ArchicadObject
     // Guid of the group the element belongs to; empty when ungrouped. A SEPARATE,
     // overlapping axis from layerInfo — an element keeps its layer AND its group.
     std::string groupId = "";
+
+    // Zone occupancy/boundary (zones) or the two zones an opening connects (openings).
+    // Empty for every other element type.
+    ArchicadRoomTopology roomInfo;
 
     // Populated (valid == true) only for GDL/library-part "Object" leaves that were
     // extracted as an instance. When valid, displayValue is left empty and the object

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
@@ -25,6 +25,10 @@ struct ArchicadObject
     // main emit loop, once it is known whether the host was itself converted.
     std::string hostElementId = "";
 
+    // Guid of the group the element belongs to; empty when ungrouped. A SEPARATE,
+    // overlapping axis from layerInfo — an element keeps its layer AND its group.
+    std::string groupId = "";
+
     // Populated (valid == true) only for GDL/library-part "Object" leaves that were
     // extracted as an instance. When valid, displayValue is left empty and the object
     // is emitted as an INSTANCE of a shared DEFINITION rather than baked geometry.

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadObject.h
@@ -4,6 +4,7 @@
 #include "EavLeaf.h"
 #include "ElementBody.h"
 #include "ArchicadLevel.h"
+#include "ArchicadLayer.h"
 #include "ObjectInstance.h"
 
 struct ArchicadObject
@@ -17,6 +18,7 @@ struct ArchicadObject
     EavLeaves properties; // pre-flattened EAV rows (no nested json tree)
     std::vector<ArchicadObject> elements;
     ArchicadLevel levelInfo;
+    ArchicadLayer layerInfo;
 
     // Populated (valid == true) only for GDL/library-part "Object" leaves that were
     // extracted as an instance. When valid, displayValue is left empty and the object

--- a/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadRoomTopology.h
+++ b/AddOns/Speckle/Sources/AddOn/DataTypes/ArchicadRoomTopology.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+// Spatial topology read off an element via ACAPI_Element_GetRelations. Only one half is
+// ever populated: the zone half for API_ZoneID elements, the opening half for
+// doors/windows/skylights.
+//
+// Guids only — they are resolved to bundle relations after the whole selection has been
+// emitted, since an endpoint may not be a sent object.
+struct ArchicadRoomTopology
+{
+    // ── zone side (API_RoomRelation) ──────────────────────────────────────
+    // Elements that OCCUPY the zone (furniture, lamps, openings, stairs, ...) -> IN_ROOM.
+    std::vector<std::string> occupantElementIds;
+    // Wall parts that BORDER the zone polygon -> BOUNDS.
+    std::vector<std::string> boundingElementIds;
+
+    // ── opening side (API_CWPanelRelation) ────────────────────────────────
+    // The two zones a door/window/skylight connects. Either may be empty (an opening on an
+    // exterior wall has only one side inside a zone). -> CONNECTS_TO, scoped by the opening.
+    std::string fromRoomId = "";
+    std::string toRoomId = "";
+};

--- a/Libs/bundlespec/README.md
+++ b/Libs/bundlespec/README.md
@@ -1,1 +1,10 @@
-﻿Vendored from speckle-bundle-spec 5.0.0 (schema_version 5) generated/cpp/envelope_spec.h. Regenerate with 'npm run generate' in the spec repo and re-copy; do not edit by hand.
+Vendored from speckle-bundle-spec (schema_version 5) generated/cpp/envelope_spec.h.
+
+Pinned to spec commit 93fa141a07f615895a2d6755beb43ba153ae5676 (2026-07-21).
+
+NOTE: the spec's package.json version (5.0.0) does NOT change on additive
+vocabulary edits — rel types have been un-retired (IN_GROUP 17, HOSTED_ON 22)
+without a version bump. Compare against the commit hash above, not the version
+string, when checking whether this copy is stale.
+
+Regenerate with 'npm run generate' in the spec repo and re-copy; do not edit by hand.

--- a/Libs/bundlespec/include/envelope_spec.h
+++ b/Libs/bundlespec/include/envelope_spec.h
@@ -21,7 +21,9 @@ enum class Rel : int {
   IN_MODEL = 11,
   IN_ROOM = 12,
   IN_SYSTEM = 14,
+  IN_GROUP = 17,
   CONNECTS_TO = 21,
+  HOSTED_ON = 22,
   BOUNDS = 23,
 };
 
@@ -53,7 +55,9 @@ static const RelTypeRow kRelTypes[] = {
   {11, "IN_MODEL", "object", "node", "live"},
   {12, "IN_ROOM", "object", "object", "live"},
   {14, "IN_SYSTEM", "object", "node", "live"},
+  {17, "IN_GROUP", "object", "node", "live"},
   {21, "CONNECTS_TO", "object", "object", "live"},
+  {22, "HOSTED_ON", "object", "object", "live"},
   {23, "BOUNDS", "object", "object", "live"},
 };
 static const NodeKindRow kNodeKinds[] = {
@@ -62,7 +66,7 @@ static const NodeKindRow kNodeKinds[] = {
   {3, "MATERIAL", nullptr},
   {4, "COLOR", nullptr},
   {5, "LEVEL", nullptr},
-  {7, "CONTAINER", "Collection,Model,MEP System,Network"},
+  {7, "CONTAINER", "Collection,Model,MEP System,Network,Group"},
 };
 
 }  // namespace bundlespec


### PR DESCRIPTION
Takes the Archicad connector from **6 relation types to 11**, closing most of the topology gap with the Revit connector — and adding one thing Revit does not currently ship (`IN_GROUP`).

Every commit is one plan item and builds independently.

## Before / after

| rel | before | after |
|---|---|---|
| DISPLAY, DEFINES, HAS_MATERIAL, DISPLAY_INSTANCE | ✅ | ✅ |
| ON_LEVEL | ✅ | ✅ |
| SUBELEMENT | beams/columns only | **+ curtain wall parts, + openings→host** |
| **IN_COLLECTION** | ✗ | ✅ layers |
| **IN_GROUP** | ✗ | ✅ groups |
| **IN_ROOM** | ✗ | ✅ zone occupancy |
| **BOUNDS** | ✗ | ✅ zone boundary walls |
| **CONNECTS_TO** | ✗ | ✅ zone adjacency through openings |

Default scene view goes from `Story → Type` to `Story → Layer → Type`.

## Commits

1. **`fdd93d4` Refresh vendored bundle spec header** — re-copy from `speckle-bundle-spec`; `IN_GROUP (17)` and `HOSTED_ON (22)` were un-retired after the header was first vendored. Purely additive, no code change (nothing switches exhaustively on `bundlespec::Rel`). README now pins by **commit**, not version string — the spec's `package.json` stayed at `5.0.0` across both un-retirements, so a version check would never have flagged the drift.
2. **`d6cded6` Layers → IN_COLLECTION** — layer index rides on `API_Elem_Head::layer`, so no extra ACAPI call; name resolution goes through the cached `GetAttributeName`. Flat (Archicad layers do not nest).
3. **`dd7ecc1` Openings → host edge** — `API_WindowType::owner` / `API_SkylightType::owner`, already in the fetched element. Introduces `EmitContext` + a deferred second pass for object→object edges. *(Originally emitted HOSTED_ON; superseded by commit 7.)*
4. **`5c0083f` Groups → IN_GROUP** — `API_Elem_Head::groupGuid`, free.
5. **`dc12108` Curtain walls → SUBELEMENT** — frames/panels/junctions/accessories become real children. Also fixes a pre-existing duplication bug.
6. **`211465f` Zones → IN_ROOM + BOUNDS + CONNECTS_TO** — `ACAPI_Element_GetRelations`.
7. **`c7b9c98` Openings use SUBELEMENT, not HOSTED_ON** — align with Revit; see below.

## Design notes worth reviewing

**Openings use SUBELEMENT directed host→hosted.** This PR originally emitted `HOSTED_ON`, whose semantics fit better — an opening is *placed on* a wall rather than being a component of it, and Archicad's own API draws that line (`owner` guid vs `ACAPI_HierarchicalEditing_GetHierarchicalElementOwner`). But a grep across every connector confirms **nothing emits HOSTED_ON**: the spec un-retired it (ENG-8867) and the SDK shipped the façade, but no producer adopted it and the .NET receive side has no map for it. Revit does `pipeline.Subelement(parentK, elementK)` for `FamilyInstance.Host ?? .SuperComponent`, so Archicad now matches.

Direction is load-bearing here: HOSTED_ON is hosted→host, SUBELEMENT is host→hosted. The viewer labels SUBELEMENT edges by direction (`children` outgoing from the wall, `host` incoming on the door), so a straight relation-id swap would have inverted both labels.

**SUBELEMENT ordinals come from a per-parent counter** shared by the child walk and the deferred hosting pass, so a curtain wall that also hosts a door cannot hand out ordinal `0` twice. Revit passes a literal `0` for the host edge and has the same latent collision.

**Curtain walls needed no geometry refactor.** `GetArchicadObject` only extracts a body for an element with *no* children, so once `GetElementChildren` reports the CW parts the parent contributes no geometry and each child gets its own body through the existing path. A CW previously shipped as one object whose geometry was every part merged into per-material blobs.

**CW segments are excluded** from the child set: no body of their own, and neither `API_CWFrameType` nor `API_CWPanelType` has a back-reference to its segment, so a `CW → segment → frame` tier can't be rebuilt from the child side. Hierarchy is flat.

**Pre-existing duplication bug fixed.** `GetElementList` maps one type filter onto the parent *and* its sub-types (`"CurtainWall"` → the wall plus Frame/Panel/…; same for Stair and Railing), so that filter returned both tiers. `FilterOutHierarchicalChildren` is the Archicad counterpart to Revit's `RemoveKnownChildElementsWhenParentPresent`. Elements whose ownership can't be determined are **kept** — a duplicate is a safer failure than a silent drop.

**IN_ROOM uses an allowlist.** `elementsGroupedByType` returns *everything* related to a zone, walls and slabs included. Emitting IN_ROOM for those would claim a wall "occupies" the room; enclosure is what BOUNDS is for.

**CONNECTS_TO needed no derivation.** Openings report their two zones directly (`API_CWPanelRelation{fromRoom, toRoom}`) — the exact analogue of Revit's `FromRoom`/`ToRoom`. Scoped by the opening's object K.

All object→object edges resolve in one deferred pass, guarded on **both** endpoints being sent objects — interning an unsent guid would mint a phantom object row with no properties or geometry.

## Verification

Builds clean on **AC27, AC28 and AC29** (Debug/x64). @dkekesi is running the model testing; layers, groups and hosting are confirmed working in the viewer.

```sql
SELECT t.name, count(*)
FROM read_parquet('{v}.envelope.relations.parquet') r
JOIN read_parquet('{v}.envelope.rel_types.parquet') t ON t.rel = r.rel
GROUP BY 1 ORDER BY 2 DESC;
```

Note the join is on `t.rel`, not `t.id` — the catalog ships the reduced four-column schema, matching the C# `EnvelopeWriter`.

Two things still need a real model to confirm:
- **Zones are not in a default send.** They have no 3D representation, so `APIFilt_In3D` excludes them; they arrive only via the `"Zone"` type filter or explicit selection — same trap as Revit's "Append rooms and areas". All three zone relations are silently empty otherwise.
- **Curtain wall object counts.** A CW can be hundreds of parts. Worth measuring before this ships.

## Open questions

1. **Group nesting is not implemented.** Groups do nest, and a group's own `header.groupGuid` *should* give its parent — inferred from headers, not runtime-verified. Flat is correct and useful on its own.
2. **Group labels are synthetic.** Archicad groups are anonymous — no `API_GroupType`, no name field — so labels are `"Group {first guid block}"`.
3. **Zone send setting** — should zones be opt-in via a visible setting rather than only reachable through the type filter?
4. **HOSTED_ON is now dead vocabulary.** It ships in the catalog but no connector emits it. Either some producer should adopt it or it's a candidate for re-retirement — worth a decision rather than leaving it in limbo.

Also worth noting: `speckle-sharp-connectors/docs/connector-topology.md` still lists HOSTED_ON and IN_GROUP as "retired — do NOT use". That's stale for IN_GROUP and misleading for HOSTED_ON (un-retired in the spec, unused in practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
